### PR TITLE
docs(course): 新增 WebAuthn/Passkeys 互動式學習課程

### DIFF
--- a/docs/course/index.html
+++ b/docs/course/index.html
@@ -1,0 +1,125 @@
+<!DOCTYPE html>
+<html lang="zh-TW">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>WebAuthn &amp; Passkeys：從基礎到實戰</title>
+  <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+  <div id="app">
+    <header class="course-header">
+      <div class="header-inner">
+        <div class="header-brand">
+          <span class="header-icon">&#x1f511;</span>
+          <div>
+            <h1 class="header-title">WebAuthn &amp; Passkeys</h1>
+            <p class="header-sub">從基礎到實戰的完整學習計畫</p>
+          </div>
+        </div>
+        <div class="header-progress">
+          <span id="progress-label">0 / 9 課程</span>
+          <div class="progress-bar"><div class="progress-fill" id="progress-fill"></div></div>
+        </div>
+      </div>
+    </header>
+
+    <div class="layout">
+      <nav class="sidebar" id="sidebar">
+        <div class="sidebar-heading">課程目錄</div>
+        <ul id="lesson-list" class="lesson-list"></ul>
+        <div class="sidebar-meta">
+          <p>基於 13 個研究領域的 176 項發現</p>
+          <p>資料來源：W3C WebAuthn L3、CTAP 2.3、NIST SP 800-63-4</p>
+        </div>
+      </nav>
+
+      <main class="main" id="main-content">
+        <!-- 總覽 -->
+        <section id="overview-section" class="overview-section">
+          <div class="overview-card">
+            <h2>課程總覽</h2>
+            <p>一套完整的 8 堂課程，涵蓋 WebAuthn / FIDO2 / Passkeys 的所有生態系。基於 13 個研究領域的 176 項研究發現，使用最新規格資料編寫而成。</p>
+            <div class="overview-stats">
+              <div class="stat"><span class="stat-num">8</span><span class="stat-label">堂課</span></div>
+              <div class="stat"><span class="stat-num">150</span><span class="stat-label">預估時數</span></div>
+              <div class="stat"><span class="stat-num">162</span><span class="stat-label">核心概念</span></div>
+              <div class="stat"><span class="stat-num">24</span><span class="stat-label">學習卡片</span></div>
+            </div>
+            <button class="btn-primary" id="btn-start">開始學習</button>
+          </div>
+          <div class="overview-toc">
+            <h3>你將學到什麼</h3>
+            <ol id="toc-list" class="toc-list"></ol>
+          </div>
+          <div class="overview-sources">
+            <h3>主要參考資料</h3>
+            <div class="source-cards" id="overview-sources"></div>
+          </div>
+        </section>
+
+        <!-- 課程內容 -->
+        <section id="lesson-section" class="lesson-section" style="display:none;">
+          <div class="lesson-topbar">
+            <button class="btn-back" id="btn-back-overview">&larr; 回到總覽</button>
+            <span class="lesson-tag" id="lesson-difficulty"></span>
+          </div>
+          <article class="lesson-article">
+            <div class="lesson-number" id="lesson-number"></div>
+            <h2 class="lesson-title" id="lesson-title"></h2>
+            <div class="objectives-block" id="objectives-block">
+              <h4>學習目標</h4>
+              <ul id="objectives-list"></ul>
+            </div>
+            <div class="lesson-body" id="lesson-body"></div>
+
+            <div class="flashcard-section">
+              <h3>學習卡片</h3>
+              <div class="flashcard-deck" id="flashcard-deck"></div>
+            </div>
+
+            <div class="quiz-section">
+              <h3>隨堂測驗</h3>
+              <div id="quiz-container"></div>
+            </div>
+
+            <div class="source-section">
+              <h3>參考資料與來源</h3>
+              <div class="source-cards" id="lesson-sources"></div>
+            </div>
+
+            <div class="lesson-nav">
+              <button class="btn-secondary" id="btn-prev" disabled>&larr; 上一課</button>
+              <button class="btn-complete" id="btn-complete">完成並繼續 &rarr;</button>
+              <button class="btn-secondary" id="btn-next">下一課 &rarr;</button>
+            </div>
+          </article>
+        </section>
+
+        <!-- 總複習 -->
+        <section id="review-section" class="review-section" style="display:none;">
+          <h2>總複習測驗</h2>
+          <p class="review-intro">綜合 8 堂課程的所有知識，測試你對整個 WebAuthn / Passkeys 生態系的理解程度。</p>
+          <div id="review-quiz"></div>
+          <div class="review-score" id="review-score" style="display:none;"></div>
+          <button class="btn-primary" id="btn-check-review" style="display:none;">檢查所有答案</button>
+          <button class="btn-back" id="btn-back-from-review" style="margin-top:1.5rem;">&larr; 回到總覽</button>
+        </section>
+      </main>
+    </div>
+  </div>
+  <!-- 課程資料（每章獨立檔案，方便增修） -->
+  <script src="lessons/lesson-1.js"></script>
+  <script src="lessons/lesson-2.js"></script>
+  <script src="lessons/lesson-3.js"></script>
+  <script src="lessons/lesson-4.js"></script>
+  <script src="lessons/lesson-5.js"></script>
+  <script src="lessons/lesson-6.js"></script>
+  <script src="lessons/lesson-7.js"></script>
+  <script src="lessons/lesson-8.js"></script>
+  <script src="lessons/appendix-a.js"></script>
+  <script src="lessons/review.js"></script>
+  <!-- 應用邏輯 -->
+  <script src="script.js"></script>
+</body>
+</html>

--- a/docs/course/lessons/appendix-a.js
+++ b/docs/course/lessons/appendix-a.js
@@ -1,0 +1,212 @@
+/* 附錄 A：Step-Up Authentication（升級認證） */
+const APPENDIX_A = {
+  id: 9,
+  title: "附錄 A：Step-Up Authentication（升級認證）",
+  difficulty: "intermediate",
+  objectives: [
+    "定義 Step-Up Authentication 及其在應用程式安全中的角色",
+    "區分高保證（high-assurance）與低保證（low-assurance）裝置，並說明如何分類",
+    "使用 allowCredentials 限制升級認證只接受高保證憑證",
+    "設計完整的 Step-Up Authentication 流程，包括資料庫結構與 FIDO MDS 整合"
+  ],
+  body: `
+    <h3>什麼是 Step-Up Authentication？</h3>
+    <p>Step-Up Authentication（升級認證）是一種安全機制，<strong>對應用程式中的敏感或關鍵操作施加額外的認證要求</strong>。使用者可能一開始用較低保證等級的方式登入（例如同步 Passkey），但在執行敏感操作時，系統會要求使用較高保證等級的驗證器重新認證。</p>
+
+    <div class="callout">核心概念：不是所有操作都需要最高等級的認證。日常瀏覽用 Passkey 就夠了，但轉帳超過一定金額時，系統應該要求使用硬體安全金鑰重新驗證。</div>
+
+    <h3>什麼時候需要升級認證？</h3>
+    <p>典型的場景包括：</p>
+    <ul>
+      <li><strong>金融交易</strong>——銀行允許多種驗證器登入，但超過特定金額（例如 $1,000）的轉帳需要高保證裝置</li>
+      <li><strong>帳號安全設定</strong>——變更密碼、綁定新的認證方式、修改通知設定</li>
+      <li><strong>敏感資料存取</strong>——檢視完整的社會安全號碼、下載個人資料匯出檔</li>
+      <li><strong>管理員操作</strong>——變更權限、刪除使用者、存取稽核日誌</li>
+      <li><strong>電子簽章或法律文件</strong>——需要更強的身分驗證來確保不可否認性</li>
+    </ul>
+
+    <h3>裝置保證等級分類</h3>
+    <p>Step-Up Authentication 的前提是能區分驗證器的保證等級：</p>
+
+    <p><strong>低保證裝置（Low-Assurance）：</strong></p>
+    <ul>
+      <li>缺少證明聲明（attestation statement）的註冊</li>
+      <li>未綁定特定硬體的憑證</li>
+      <li>可複製的 Passkeys（同步憑證，BE=1）</li>
+      <li>軟體式驗證器</li>
+    </ul>
+
+    <p><strong>高保證裝置（High-Assurance）：</strong></p>
+    <ul>
+      <li>具有硬體證明的驗證器（attestation='direct'）</li>
+      <li>透過 FIDO Metadata Service（MDS）驗證過的裝置</li>
+      <li>裝置綁定的憑證（BE=0, BS=0）</li>
+      <li>FIDO 認證 L2 以上的硬體安全金鑰（如 YubiKey）</li>
+    </ul>
+
+    <h3>實作流程</h3>
+    <p>完整的 Step-Up Authentication 流程如下：</p>
+    <ol>
+      <li>使用者嘗試執行敏感操作（如大額轉帳）</li>
+      <li>伺服器檢查使用者目前 session 的認證保證等級</li>
+      <li><strong>快樂路徑：</strong>初始認證已使用高保證裝置 → 操作直接放行</li>
+      <li><strong>升級路徑：</strong>初始認證使用低保證裝置 → 系統提示使用高保證裝置重新認證</li>
+      <li>重新認證成功後，敏感操作完成</li>
+    </ol>
+
+    <h3>資料庫結構</h3>
+    <p>在憑證儲存模型中加入 <code>is_high_assurance</code> 欄位，在註冊時根據證明分析和 MDS 查詢來計算：</p>
+    <pre>-- 憑證資料表（加入保證等級欄位）
+credential_id     VARCHAR(1023) PRIMARY KEY
+public_key        BYTEA
+counter           BIGINT
+user_id           UUID REFERENCES users(id)
+aaguid            CHAR(36)
+transports        TEXT[]
+backup_eligible   BOOLEAN
+backup_state      BOOLEAN
+is_high_assurance BOOLEAN DEFAULT false  -- 升級認證用
+registration_time TIMESTAMPTZ
+last_used_time    TIMESTAMPTZ</pre>
+
+    <p><code>is_high_assurance</code> 的判斷邏輯：</p>
+    <pre>function classifyAssurance(attestation, mdsEntry) {
+  // 有有效證明 + MDS 中查得到 + 非同步憑證 = 高保證
+  if (attestation.fmt !== "none"
+      && mdsEntry !== null
+      && mdsEntry.certificationLevel >= 2
+      && !backupEligible) {
+    return true;
+  }
+  return false;
+}</pre>
+
+    <h3>前提條件：FIDO Metadata Service（MDS）</h3>
+    <p>要判斷裝置的保證等級，你需要整合 FIDO MDS：</p>
+    <ul>
+      <li>MDS 是 FIDO 聯盟維護的公開資料庫，包含已認證驗證器的中繼資料</li>
+      <li>透過 AAGUID 查詢可以得到：認證等級、支援的演算法、證明憑證鏈、安全公告</li>
+      <li>伺服器端函式庫如 <code>java-webauthn-server</code>（Yubico）和 <code>fido2-net-lib</code>（.NET）有內建的 MDS 整合</li>
+    </ul>
+
+    <h3>關鍵實作：用 allowCredentials 限制升級認證</h3>
+    <p>升級認證時，<strong>只允許高保證憑證</strong>。透過 <code>allowCredentials</code> 只列出標記為高保證的 credential ID：</p>
+    <pre>// 伺服器端：產生升級認證選項
+async function generateStepUpOptions(userId) {
+  // 只取該使用者的高保證憑證
+  const highAssuranceCreds = await db.getCredentials(userId, {
+    isHighAssurance: true
+  });
+
+  if (highAssuranceCreds.length === 0) {
+    throw new Error("此使用者沒有註冊高保證裝置，無法進行升級認證");
+  }
+
+  return {
+    challenge: crypto.randomBytes(32),
+    rpId: "example.com",
+    userVerification: "required",
+    allowCredentials: highAssuranceCreds.map(c => ({
+      type: "public-key",
+      id: c.credentialId,
+      transports: c.transports
+    })),
+    timeout: 120000  // 升級認證給較短的 timeout
+  };
+}</pre>
+
+    <pre>// 客戶端：觸發升級認證
+async function performStepUp() {
+  const options = await fetch("/auth/step-up/options", {
+    method: "POST"
+  }).then(r => r.json());
+
+  const assertion = await navigator.credentials.get({
+    publicKey: PublicKeyCredential.parseRequestOptionsFromJSON(options)
+  });
+
+  const result = await fetch("/auth/step-up/verify", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(assertion.toJSON())
+  }).then(r => r.json());
+
+  if (result.success) {
+    // 升級認證成功，繼續敏感操作
+    proceedWithSensitiveAction();
+  }
+}</pre>
+
+    <h3>Session 中的升級狀態管理</h3>
+    <p>升級認證成功後，在 session 中記錄時間戳記，並設定有效期限：</p>
+    <pre>// 升級認證成功後
+session.stepUpVerifiedAt = Date.now();
+session.stepUpExpiresAt = Date.now() + 5 * 60 * 1000; // 5 分鐘
+
+// 檢查升級狀態的 middleware
+function requireStepUp(req, res, next) {
+  if (!req.session.stepUpExpiresAt
+      || Date.now() > req.session.stepUpExpiresAt) {
+    return res.status(403).json({
+      error: "step_up_required",
+      message: "此操作需要升級認證"
+    });
+  }
+  next();
+}</pre>
+
+    <div class="callout-critical callout"><strong>升級認證的時效必須很短</strong>（建議 5-15 分鐘）。過長的有效期會降低安全性——使用者可能已經離開座位，讓別人接手操作。每次敏感操作都應該重新檢查時效。</div>
+
+    <h3>與 NIST AAL 的對應</h3>
+    <ul>
+      <li><strong>AAL1</strong>（單因子）——密碼登入。不適合任何敏感操作。</li>
+      <li><strong>AAL2</strong>（多因子，抗釣魚）——同步 Passkeys 符合此等級（NIST SP 800-63-4）。適合一般操作。</li>
+      <li><strong>AAL3</strong>（硬體綁定，驗證器模擬抵抗）——裝置綁定 Passkeys、FIDO 認證 L2+ 硬體金鑰。敏感操作應要求此等級。</li>
+    </ul>
+    <p>Step-Up Authentication 本質上就是：讓使用者在需要時，從 AAL2 升級到 AAL3。</p>
+
+    <h3>最佳實踐</h3>
+    <ul>
+      <li><strong>預先儲存保證等級</strong>——在註冊時就計算並儲存 <code>is_high_assurance</code>，不要每次認證時才動態計算（效能考量）</li>
+      <li><strong>引導使用者註冊高保證裝置</strong>——在使用者首次遇到升級認證需求時，提供註冊硬體安全金鑰的選項</li>
+      <li><strong>清楚的 UX 訊息</strong>——告訴使用者為什麼需要額外驗證，以及可以用哪些裝置</li>
+      <li><strong>降級處理</strong>——如果使用者沒有高保證裝置，提供替代流程（如人工審核、延遲執行）</li>
+      <li><strong>稽核日誌</strong>——記錄所有升級認證的嘗試和結果，包括使用了哪個憑證</li>
+    </ul>
+  `,
+  flashcards: [
+    { front: "什麼是 Step-Up Authentication？", back: "一種安全機制，在使用者已經登入的情況下，對敏感或關鍵操作要求額外的、更高保證等級的認證。例如使用者用同步 Passkey（AAL2）登入後，執行大額轉帳時需要用硬體安全金鑰（AAL3）重新驗證。本質上是從 AAL2 升級到 AAL3。" },
+    { front: "升級認證時如何限制只接受高保證裝置？", back: "在 PublicKeyCredentialRequestOptions 的 allowCredentials 陣列中，只列出標記為 is_high_assurance = true 的 credential ID。這樣瀏覽器只會提示使用者用高保證的驗證器（如硬體安全金鑰），而不會接受同步 Passkey。" },
+    { front: "如何判斷一個憑證是否為高保證？", back: "在註冊時根據三個條件判斷：(1) 具有有效的證明聲明（attestation.fmt !== 'none'），(2) 在 FIDO MDS 中查得到該 AAGUID 且認證等級 >= L2，(3) 不是可同步的憑證（BE=0）。在資料庫中用 is_high_assurance 布林欄位儲存，避免每次認證時動態計算。" }
+  ],
+  quiz: [
+    {
+      question: "銀行應用中，使用者用同步 Passkey 登入後想轉帳 $5,000。Step-Up Authentication 應該怎麼做？",
+      options: [
+        "直接拒絕操作，要求使用者用硬體金鑰重新登入整個 session",
+        "在 allowCredentials 中只列出該使用者的高保證憑證，觸發一次新的 WebAuthn 認證典禮",
+        "顯示一個確認對話框讓使用者點擊「確認」",
+        "發送 SMS OTP 作為額外驗證"
+      ],
+      correct: 1,
+      explanation: "正確做法是觸發一次新的 WebAuthn 認證典禮，但在 allowCredentials 中只列出標記為高保證的 credential ID（例如硬體安全金鑰）。這樣使用者不需要重新登入整個 session，只需要用高保證裝置額外驗證一次。SMS OTP 不符合抗釣魚要求。"
+    },
+    {
+      question: "升級認證成功後的時效應該設定多長？",
+      options: [
+        "24 小時——一天只需要驗證一次",
+        "與 session 相同——直到登出都有效",
+        "5-15 分鐘——短時效確保安全性",
+        "不需要時效——升級後永久有效"
+      ],
+      correct: 2,
+      explanation: "升級認證的時效應該很短（建議 5-15 分鐘）。過長的有效期降低安全性——使用者可能已經離開座位讓別人接手。每次敏感操作都應該重新檢查時效，過期就要求重新進行升級認證。"
+    }
+  ],
+  sources: [
+    { title: "Yubico: Step-Up Authentication Implementation Guidance", url: "https://developers.yubico.com/WebAuthn/Concepts/Authenticator_Management/Implementation_Guidance/Step_Up_Authentication.html" },
+    { title: "NIST SP 800-63-3: Digital Identity Guidelines", url: "https://pages.nist.gov/800-63-3/" },
+    { title: "FIDO Alliance Metadata Service (MDS)", url: "https://fidoalliance.org/metadata/" },
+    { title: "W3C WebAuthn Level 3: Assertion Options", url: "https://www.w3.org/TR/webauthn-3/#sctn-credentialrequestoptions-extension" }
+  ]
+};

--- a/docs/course/lessons/lesson-1.js
+++ b/docs/course/lessons/lesson-1.js
@@ -1,0 +1,81 @@
+/* 第 1 課 */
+const LESSON_1 = {
+    id: 1,
+    title: "密碼的困境與 FIDO 的演進",
+    difficulty: "beginner",
+    objectives: [
+      "說明密碼為何在結構上就是有缺陷的，並辨識各種傳統 MFA 方法的攻擊向量",
+      "追溯從 FIDO UAF/U2F (2014) 到 FIDO2 (2018) 再到 Passkeys (2022+) 的演進歷程",
+      "描述 FIDO 聯盟的使命，以及全球監管機構轉向抗釣魚認證的趨勢",
+      "闡述 Passkeys 如何「從設計上」消除整個攻擊類別，而非只是做風險緩解"
+    ],
+    body: `
+      <h3>密碼為什麼行不通？</h3>
+      <p>根據 Verizon DBIR 報告，77% 的駭客入侵事件涉及被竊取或弱密碼。密碼的根本問題在於它是<strong>共享秘密（shared secret）</strong>——它同時存在於使用者端和伺服器端。任何共享秘密都可以被釣魚、外洩或暴力破解。</p>
+      <p>第二因子驗證方法嘗試解決這個問題，但各自帶來了新的弱點：</p>
+      <ul>
+        <li><strong>SMS OTP</strong>——容易被 SIM 卡劫持（SIM swap）、SS7 攔截</li>
+        <li><strong>TOTP</strong>（如 Google Authenticator）——容易被即時中間人代理攻擊（AiTM）即時轉發驗證碼</li>
+        <li><strong>推播通知</strong>——容易被 MFA 疲勞攻擊（一直彈出提示直到使用者按同意）</li>
+      </ul>
+
+      <h3>FIDO 聯盟</h3>
+      <p>FIDO（Fast IDentity Online）聯盟於 2013 年 2 月成立，目前有超過 250 個成員（Apple、Google、Microsoft、Amazon、Visa、Mastercard 等）。它的使命是解決密碼的<em>結構性失敗</em>——不是改善密碼，而是用公鑰加密技術完全取代密碼。</p>
+
+      <h3>演進時間軸</h3>
+      <ul>
+        <li><strong>2014 年 12 月</strong>——FIDO 1.0：UAF（無密碼生物辨識）及 U2F（硬體安全金鑰作為第二因子）</li>
+        <li><strong>2018 年</strong>——FIDO2 發布：結合 WebAuthn（W3C 瀏覽器 API）+ CTAP2（驗證器協定）</li>
+        <li><strong>2019 年 3 月</strong>——WebAuthn 成為 W3C 正式網頁標準</li>
+        <li><strong>2022 年</strong>——Apple iOS 16、Google、Microsoft 宣布支援 Passkeys（跨裝置同步憑證）</li>
+        <li><strong>2025 年 5 月</strong>——Microsoft 將 Passkeys 設為預設登入方式</li>
+        <li><strong>2025 年 7 月</strong>——NIST SP 800-63-4 正式認可同步 Passkeys 符合 AAL2 等級</li>
+        <li><strong>2026 年</strong>——全球 50 億個活躍 Passkeys；阿聯酋、印度、菲律賓禁用 SMS OTP</li>
+      </ul>
+
+      <div class="callout">Passkeys 不是「又一種 MFA 方法」。它從根本上消除了共享秘密——伺服器永遠不會儲存任何可以被釣魚或外洩的東西。</div>
+
+      <h3>採用里程碑（2026 年）</h3>
+      <ul>
+        <li>150 億個使用者帳號可使用 FIDO2 認證</li>
+        <li>69% 的消費者至少擁有一個 Passkey</li>
+        <li>前 100 大網站中有 48% 支援 Passkeys</li>
+        <li>87% 的企業正在部署或試行 FIDO2</li>
+      </ul>
+    `,
+    flashcards: [
+      { front: "密碼的根本安全缺陷是什麼？", back: "密碼是共享秘密（shared secret）——它同時存在於客戶端和伺服器端。任何共享秘密都可以被釣魚、外洩、暴力破解或攔截。WebAuthn 使用非對稱公鑰加密技術來消除這個問題，伺服器端永遠不持有任何秘密。" },
+      { front: "FIDO2 由哪兩個部分組成？", back: "FIDO2 恰好由兩個元件組成：WebAuthn（W3C 瀏覽器 JavaScript API，負責註冊和認證）以及 CTAP2（FIDO 聯盟的 Client-to-Authenticator Protocol，負責瀏覽器/OS 與外部驗證器之間透過 USB、NFC 或藍牙的通訊）。" },
+      { front: "為什麼 TOTP（驗證器 App）仍然容易被釣魚？", back: "TOTP 驗證碼在一個時間窗口內有效（通常 30 秒）。中間人代理（AiTM）可以即時將驗證碼轉發到真正的伺服器。TOTP 沒有來源綁定（origin binding）——無論使用者在哪個網站輸入，驗證碼都能用。" }
+    ],
+    quiz: [
+      {
+        question: "FIDO 聯盟為什麼選擇公鑰加密技術，而不是改善密碼？",
+        options: [
+          "密碼是結構性問題（共享秘密），無法透過增加強度來修復",
+          "密碼對於現代認證來說太慢了",
+          "公鑰加密技術的實作成本比密碼雜湊更低",
+          "瀏覽器原生不支援基於密碼的認證"
+        ],
+        correct: 0,
+        explanation: "核心問題在於密碼是儲存在伺服器上的共享秘密。無論怎麼加強雜湊、加鹽或複雜度要求，都無法消除伺服器端秘密可被竊取的根本弱點。公鑰加密技術確保伺服器端完全不儲存任何秘密。"
+      },
+      {
+        question: "2025 年 7 月，Passkeys 達成了什麼監管里程碑？",
+        options: [
+          "歐盟禁止所有基於密碼的認證",
+          "NIST SP 800-63-4 正式認可同步 Passkeys 符合 AAL2 等級",
+          "FIDO 聯盟強制要求所有網站使用 Passkeys",
+          "WebAuthn Level 3 成為 W3C 正式推薦標準"
+        ],
+        correct: 1,
+        explanation: "NIST SP 800-63-4（2025 年 7 月）正式認可同步 Passkeys 符合 Authenticator Assurance Level 2（AAL2），為企業採用提供了監管基礎。這是一個關鍵里程碑，因為先前的 NIST 指引並未明確涵蓋同步憑證。"
+      }
+    ],
+    sources: [
+      { title: "Verizon Data Breach Investigations Report", url: "https://www.verizon.com/business/resources/reports/dbir/" },
+      { title: "FIDO Alliance Specifications", url: "https://fidoalliance.org/specifications/" },
+      { title: "NIST SP 800-63-4 Digital Identity Guidelines", url: "https://pages.nist.gov/800-63-4/" },
+      { title: "FIDO Alliance: A Brief History", url: "https://www.daon.com/resource/a-brief-history-of-fido/" }
+    ]
+  };

--- a/docs/course/lessons/lesson-2.js
+++ b/docs/course/lessons/lesson-2.js
@@ -1,0 +1,76 @@
+/* 第 2 課 */
+const LESSON_2 = {
+    id: 2,
+    title: "加密基礎知識",
+    difficulty: "beginner",
+    objectives: [
+      "說明非對稱加密如何消除 WebAuthn 中的共享秘密",
+      "辨識三種主要簽章演算法（ES256、RS256、EdDSA）及其 COSE 識別碼",
+      "描述 CBOR 和 COSE 編碼格式，以及 WebAuthn 選擇它們而非 JSON 的原因",
+      "追蹤驗證器在典禮（ceremony）中實際簽署了什麼資料"
+    ],
+    body: `
+      <h3>WebAuthn 中的公鑰加密</h3>
+      <p>WebAuthn 使用<strong>非對稱金鑰對</strong>：私鑰（儲存在驗證器的安全晶片中）和公鑰（儲存在伺服器上）。伺服器<em>永遠</em>不持有秘密。認證時，驗證器透過簽署挑戰（challenge）來證明它持有私鑰——簽章可以用公鑰驗證，但無法用來推導出私鑰。</p>
+
+      <h3>簽章演算法</h3>
+      <p>WebAuthn 使用 COSE（CBOR Object Signing and Encryption）的整數識別碼來表示演算法。你必須支援以下三種：</p>
+      <ul>
+        <li><strong>ES256</strong>（COSE ID <code>-7</code>）——ECDSA 搭配 P-256 曲線 + SHA-256。支援度最廣：Apple Touch ID/Face ID、Android、Windows 11+、大多數安全金鑰。約 128 位元安全性。公鑰 = 64 位元組（32 位元組 x + 32 位元組 y）。</li>
+        <li><strong>RS256</strong>（COSE ID <code>-257</code>）——RSA PKCS#1 v1.5 + SHA-256。Windows 10 Hello（TPM）必需。最少 2048 位元金鑰。</li>
+        <li><strong>EdDSA</strong>（COSE ID <code>-8</code>）——Ed25519。YubiKey 5.2+ 和 SoloKey 支援。速度快、32 位元組精簡公鑰。</li>
+      </ul>
+      <pre>// 建議的 pubKeyCredParams 陣列
+pubKeyCredParams: [
+  { type: "public-key", alg: -7   }, // ES256
+  { type: "public-key", alg: -257 }, // RS256
+  { type: "public-key", alg: -8   }, // EdDSA
+]</pre>
+
+      <h3>CBOR 與 COSE</h3>
+      <p><strong>CBOR</strong>（Concise Binary Object Representation，RFC 8949）是一種二進位序列化格式，比 JSON 小 20-50%。WebAuthn 用它來編碼 <code>attestationObject</code> 和 <code>credentialPublicKey</code>，因為驗證器是透過頻寬有限的通道（NFC、BLE）進行通訊。</p>
+      <p><strong>COSE_Key</strong> 使用整數標籤：正整數代表標準欄位（<code>kty=1</code>、<code>alg=3</code>），<em>負整數</em>代表演算法特定參數（<code>crv=-1</code>、<code>x=-2</code>、<code>y=-3</code>）。</p>
+      <pre>// ES256 (P-256) 的 COSE_Key
+{
+  1: 2,    // kty: EC2
+  3: -7,   // alg: ES256
+  -1: 1,   // crv: P-256
+  -2: &lt;x&gt;, // x 座標 (32 bytes)
+  -3: &lt;y&gt;  // y 座標 (32 bytes)
+}</pre>
+
+      <h3>驗證器簽署了什麼？</h3>
+      <p>認證時，驗證器簽署的內容是：</p>
+      <pre>signedData = concat(authenticatorData, SHA-256(clientDataJSON))</pre>
+      <p>這將 RP ID 雜湊值（防釣魚保護）、使用者存在/驗證旗標、簽名計數器，<em>以及</em>來自 clientDataJSON 的挑戰 + 來源，全部綁定在一個不可偽造的簽章中。</p>
+
+      <div class="callout">挑戰（challenge）是協定的加密心跳：它必須由伺服器產生、至少 16 位元組熵值（建議 32 位元組）、且只能使用一次。移除隨機性會讓安全性完全崩潰。</div>
+
+      <h3>硬體安全晶片</h3>
+      <p>私鑰在專用硬體中產生並儲存：Apple Secure Enclave、Android StrongBox Keymaster，或 TPM（Trusted Platform Module）。金鑰<em>永遠不會離開</em>安全晶片——所有簽章運算都在裡面完成。這是硬體層面的保證，不是軟體承諾。</p>
+    `,
+    flashcards: [
+      { front: "ES256 的 COSE 演算法 ID 是什麼？", back: "-7。ES256 使用 ECDSA 搭配 P-256（secp256r1）曲線和 SHA-256。它在平台驗證器中擁有最廣泛的支援度，產生 64 位元組的公鑰（32 位元組 x + 32 位元組 y 座標）。簽章採用 ASN.1 DER 編碼。" },
+      { front: "WebAuthn 為什麼用 CBOR 而不是 JSON？", back: "CBOR（Concise Binary Object Representation）比 JSON 小 20-50%，且原生支援二進位資料。這對於透過頻寬受限通道（NFC 424 Kbps、BLE 1 Mbps）通訊的驗證器來說很重要。attestationObject 和 credentialPublicKey 一律使用 CBOR 編碼。" },
+      { front: "認證時，驗證器實際簽署了什麼資料？", back: "signedData = concat(authenticatorData, SHA-256(clientDataJSON))。這涵蓋了：rpIdHash（防釣魚保護）、flags（UP/UV/BE/BS）、signCount（偵測複製）、以及來自 clientDataJSON 的 challenge 和 origin。簽章證明驗證器在典禮時持有私鑰。" }
+    ],
+    quiz: [
+      {
+        question: "為了相容 Windows 10 Hello，pubKeyCredParams 中「必須」包含哪個演算法？",
+        options: [
+          "ES256（COSE ID -7）",
+          "RS256（COSE ID -257）",
+          "EdDSA（COSE ID -8）",
+          "PS256（COSE ID -37）"
+        ],
+        correct: 1,
+        explanation: "RS256（RSA PKCS#1 v1.5 + SHA-256，COSE ID -257）是 Windows 10 Hello 特別需要的，因為它使用基於 TPM 的 RSA 金鑰。Windows 11+ 原生支援 ES256，但 RS256 確保了向後相容性。"
+      }
+    ],
+    sources: [
+      { title: "IETF RFC 8949 — CBOR", url: "https://datatracker.ietf.org/doc/html/rfc8949" },
+      { title: "IETF RFC 9052 — COSE Structures", url: "https://datatracker.ietf.org/doc/html/rfc9052" },
+      { title: "Corbado: CBOR and COSE in WebAuthn", url: "https://www.corbado.com/blog/webauthn-pubkeycredparams-credentialpublickey" },
+      { title: "WebAuthn Guide", url: "https://webauthn.guide/" }
+    ]
+  };

--- a/docs/course/lessons/lesson-3.js
+++ b/docs/course/lessons/lesson-3.js
@@ -1,0 +1,78 @@
+/* 第 3 課 */
+const LESSON_3 = {
+    id: 3,
+    title: "FIDO2 架構與三方模型",
+    difficulty: "beginner",
+    objectives: [
+      "繪製三方模型圖：信賴方（Relying Party）、客戶端/瀏覽器、驗證器",
+      "區分 WebAuthn（瀏覽器到伺服器）和 CTAP2（瀏覽器到驗證器）的範疇",
+      "用實際範例比較平台驗證器與漫遊驗證器的差異",
+      "描述 CTAP 2.1/2.2 的企業功能擴充及 FIDO 認證計畫"
+    ],
+    body: `
+      <h3>FIDO2 = WebAuthn + CTAP2</h3>
+      <p>FIDO2 是一個傘式標準，恰好由兩個元件組成：</p>
+      <ul>
+        <li><strong>WebAuthn</strong>（W3C）——瀏覽器 JavaScript API。涵蓋瀏覽器到伺服器的通訊：<code>navigator.credentials.create()</code> 和 <code>.get()</code></li>
+        <li><strong>CTAP2</strong>（FIDO 聯盟）——Client to Authenticator Protocol。涵蓋瀏覽器/OS 到驗證器的通訊，透過 USB、NFC 或藍牙</li>
+      </ul>
+
+      <h3>三方模型</h3>
+      <p>每一個 FIDO2 流程都涉及三個參與者，它們之間<em>永遠不會直接通訊</em>：</p>
+      <ol>
+        <li><strong>信賴方（Relying Party, RP）</strong>——你的網頁應用程式。負責產生挑戰、驗證回應、儲存公鑰</li>
+        <li><strong>客戶端/瀏覽器</strong>——中介所有通訊。捕捉來源（origin）、強制 HTTPS、呈現 UI</li>
+        <li><strong>驗證器（Authenticator）</strong>——產生金鑰對、將私鑰儲存在安全硬體中、產生簽章</li>
+      </ol>
+      <div class="callout">RP 和驗證器永遠不會直接通訊。瀏覽器中介一切。這個分離是根本性的——瀏覽器獨立捕捉來源（origin）作為防釣魚保護，RP 和釣魚攻擊者都無法覆寫。</div>
+
+      <h3>CTAP2 核心指令</h3>
+      <ul>
+        <li><code>authenticatorMakeCredential</code>——註冊：建立金鑰對</li>
+        <li><code>authenticatorGetAssertion</code>——認證：簽署挑戰</li>
+        <li><code>authenticatorGetInfo</code>——功能探索</li>
+        <li><code>authenticatorClientPIN</code>——PIN 管理</li>
+      </ul>
+
+      <h3>平台驗證器 vs 漫遊驗證器</h3>
+      <p><strong>平台驗證器</strong>內建在裝置中：Apple Touch ID/Face ID（Secure Enclave）、Windows Hello（TPM）、Android 生物辨識（StrongBox）。它們可以透過雲端同步憑證（iCloud 鑰匙圈、Google 密碼管理器）——這就是定義「Passkey」體驗的關鍵。</p>
+      <p><strong>漫遊驗證器</strong>是外部硬體：YubiKey、Google Titan Key、SoloKey。它們透過 USB/NFC/BLE 連接。私鑰永久綁定在實體裝置上——無法同步或匯出。搭配 FIDO 認證硬體可提供 AAL3 等級安全性。</p>
+
+      <h3>CTAP 2.1 和 2.2 新增功能</h3>
+      <ul>
+        <li><strong>企業證明（Enterprise Attestation）</strong>——序號層級的裝置識別，用於組織管控</li>
+        <li><strong>憑證管理（Credential Management）</strong>——刪除特定憑證，不需要重設整個裝置</li>
+        <li><strong>credProtect 擴充</strong>——要求使用者驗證（UV）才能存取憑證</li>
+        <li><strong>largeBlob 儲存</strong>——在驗證器上儲存憑證或資料</li>
+        <li><strong>混合傳輸（Hybrid transport）</strong>（2.2）——透過 QR 碼 + BLE 近距離驗證進行跨裝置認證</li>
+        <li><strong>CTAP 2.3</strong>（2026 年 2 月）——混合互動的多資料傳輸通道</li>
+      </ul>
+
+      <h3>FIDO 認證等級</h3>
+      <p>FIDO 聯盟營運一套累進式認證計畫：<strong>L1</strong>（協定合規）、<strong>L2</strong>（硬體隔離、認可實驗室審查）、<strong>L3</strong>（實體攻擊防禦、滲透測試）、<strong>L3+</strong>（晶片級智慧卡防禦）。</p>
+    `,
+    flashcards: [
+      { front: "FIDO2 的兩個元件是什麼？", back: "WebAuthn（W3C 瀏覽器 JavaScript API，定義瀏覽器到伺服器的通訊）和 CTAP2（FIDO 聯盟的 Client-to-Authenticator Protocol，定義瀏覽器/OS 到驗證器的通訊，透過 USB、NFC 或藍牙）。CTAP1 是舊版 U2F 協定的向後相容名稱。" },
+      { front: "平台驗證器和漫遊驗證器有什麼不同？", back: "平台驗證器內建在裝置中（Touch ID、Windows Hello、Android 生物辨識），可以透過雲端同步憑證。漫遊驗證器是外部硬體（YubiKey、Titan Key），透過 USB/NFC/BLE 連接——私鑰永久綁定且無法同步。漫遊驗證器提供 AAL3 等級；同步的平台驗證器提供 AAL2 等級。" },
+      { front: "什麼是 AAGUID？", back: "Authenticator Attestation Globally Unique Identifier——一個 16 位元組的 UUID，在註冊時嵌入 authenticatorData 中。它識別的是驗證器「型號」（例如所有 YubiKey 5 NFC 共用同一個 AAGUID），不是特定個體。搭配 FIDO MDS3 使用可查詢中繼資料和安全公告。Apple 基於隱私考量會將它歸零。" }
+    ],
+    quiz: [
+      {
+        question: "為什麼信賴方（RP）和驗證器永遠不會直接通訊？",
+        options: [
+          "因為瀏覽器會獨立捕捉來源（origin），提供任何一方都無法覆寫的防釣魚保護",
+          "因為直接通訊需要驗證器能連上網路",
+          "因為 RP 不知道使用者用的是哪種驗證器",
+          "因為 CTAP2 不支援 HTTP"
+        ],
+        correct: 0,
+        explanation: "瀏覽器作為可信的中介者，獨立記錄頁面來源到 clientDataJSON 中。這個來源無法被 JavaScript 或攻擊者覆寫。如果 RP 和驗證器直接通訊，這種獨立的來源捕捉就會被繞過，防釣魚能力就會被摧毀。"
+      }
+    ],
+    sources: [
+      { title: "Corbado: WebAuthn vs CTAP vs FIDO2", url: "https://www.corbado.com/blog/webauthn-vs-ctap-vs-fido2" },
+      { title: "Yubico: CTAP2 Developer Guide", url: "https://developers.yubico.com/CTAP/" },
+      { title: "FIDO Alliance Certification Levels", url: "https://fidoalliance.org/certification/authenticator-certification-levels/" },
+      { title: "FIDO Metadata Service", url: "https://fidoalliance.org/metadata/" }
+    ]
+  };

--- a/docs/course/lessons/lesson-4.js
+++ b/docs/course/lessons/lesson-4.js
@@ -1,0 +1,121 @@
+/* 第 4 課 */
+const LESSON_4 = {
+    id: 4,
+    title: "註冊典禮（Attestation）深入解析",
+    difficulty: "intermediate",
+    objectives: [
+      "建構完整的 PublicKeyCredentialCreationOptions 物件，包含所有必要和關鍵的選用欄位",
+      "走過從使用者操作到資料庫儲存的 10 步驟註冊典禮",
+      "解析 authenticatorData 二進位結構：rpIdHash、flags、signCount、AAGUID、credentialId、COSE 金鑰",
+      "實作伺服器端的 8 步驟註冊驗證檢查清單"
+    ],
+    body: `
+      <h3>註冊 API</h3>
+      <pre>const credential = await navigator.credentials.create({
+  publicKey: {
+    challenge: serverGeneratedBytes,      // 最少 16 bytes，建議 32
+    rp: { id: "example.com", name: "Example" },
+    user: {
+      id: opaqueUserHandle,               // 最多 64 bytes，不可放個資
+      name: "user@example.com",
+      displayName: "Jane Doe"
+    },
+    pubKeyCredParams: [
+      { type: "public-key", alg: -7 },    // ES256
+      { type: "public-key", alg: -257 },  // RS256
+      { type: "public-key", alg: -8 },    // EdDSA
+    ],
+    authenticatorSelection: {
+      residentKey: "required",             // passkeys 必要
+      userVerification: "required"
+    },
+    attestation: "none",                   // 消費者應用建議值
+    excludeCredentials: existingCreds,     // 防止重複註冊
+    timeout: 300000
+  }
+});</pre>
+
+      <h3>註冊流程（10 個步驟）</h3>
+      <ol>
+        <li>使用者在 RP 發起註冊</li>
+        <li>RP 伺服器產生加密隨機挑戰，回傳 PublicKeyCredentialCreationOptions</li>
+        <li>客戶端呼叫 <code>navigator.credentials.create({publicKey})</code></li>
+        <li>瀏覽器找到可用的驗證器</li>
+        <li>使用者執行授權手勢（PIN、生物辨識、按鈕）</li>
+        <li>驗證器產生以 RP ID 為範圍的新金鑰對</li>
+        <li>驗證器回傳公鑰 + credential ID + attestationObject</li>
+        <li>客戶端將 <code>AuthenticatorAttestationResponse</code> 回傳給腳本</li>
+        <li>腳本將 <code>{clientDataJSON, attestationObject}</code> 傳送到 RP 伺服器</li>
+        <li>RP 驗證並儲存憑證</li>
+      </ol>
+
+      <h3>authenticatorData 二進位結構</h3>
+      <pre>Bytes 0-31  : rpIdHash（RP ID 字串的 SHA-256）
+Byte  32    : flags（UP=0x01, UV=0x04, BE=0x08, BS=0x10, AT=0x40, ED=0x80）
+Bytes 33-36 : signCount（big-endian uint32）
+Bytes 37-52 : AAGUID（16 bytes，驗證器型號 ID）
+Bytes 53-54 : credentialIdLength（big-endian uint16）
+Bytes 55+   : credentialId（N bytes）
+剩餘部分    : credentialPublicKey（CBOR 編碼的 COSE_Key）</pre>
+
+      <h3>伺服器端驗證檢查清單</h3>
+      <ol>
+        <li>驗證 <code>clientDataJSON.type === "webauthn.create"</code></li>
+        <li>驗證挑戰與伺服器端儲存的挑戰一致（base64url，無填充）</li>
+        <li>驗證 <code>clientDataJSON.origin</code> 與預期的來源完全一致（必須精確字串比對！）</li>
+        <li>解析 attestationObject CBOR → 提取 authData</li>
+        <li>驗證 rpIdHash 等於你設定的 RP ID 的 SHA-256</li>
+        <li>檢查 flags：UP 必須設定；UV 若有要求也必須設定；AT 必須設定</li>
+        <li>從 attestedCredentialData 中提取 AAGUID、credentialId、credentialPublicKey</li>
+        <li>儲存：<code>{credential_id, public_key, sign_count, user_id, aaguid, transports, backup_eligible, backup_state}</code></li>
+      </ol>
+
+      <div class="callout-critical callout">Origin 必須用精確字串比對來檢查，絕對不能用子字串比對。在 evil.example.com 的子網域攻擊者會通過對 example.com 的子字串檢查。</div>
+
+      <h3>資料庫結構</h3>
+      <pre>credential_id   VARCHAR(1023) PRIMARY KEY  -- 有些 ID 非常長
+public_key      BYTEA                       -- COSE 編碼
+counter         BIGINT                      -- signCount
+user_id         UUID REFERENCES users(id)
+aaguid          CHAR(36)
+transports      TEXT[]                      -- 來自 getTransports()
+backup_eligible BOOLEAN                     -- BE 旗標
+backup_state    BOOLEAN                     -- BS 旗標
+created_at      TIMESTAMPTZ</pre>
+    `,
+    flashcards: [
+      { front: "註冊選項中 excludeCredentials 的用途是什麼？", back: "防止重複的憑證註冊。這個陣列包含使用者所有現有憑證的 {id, type, transports}。如果驗證器已經持有匹配的憑證，它會拒絕建立新的並拋出 InvalidStateError。伺服器必須在此填入使用者所有現有的 credential ID。" },
+      { front: "authenticatorData 中的 BE 和 BS 旗標是什麼？", back: "BE（Backup Eligibility，位元 3/0x08）：憑證「可以」同步到雲端。BS（Backup State，位元 4/0x10）：憑證「目前已經」備份。兩者共同識別同步 Passkeys：BE=1, BS=1 = 同步 Passkey；BE=0, BS=0 = 裝置綁定憑證。兩者都要存到資料庫中以便制定安全策略。" },
+      { front: "為什麼 credential_id 要用 VARCHAR(1023)？", back: "不同的驗證器實作會產生長度不一的 credential ID。有些會產生非常長的 ID（可達數百位元組，base64url 編碼後更長）。使用太小的 VARCHAR 會靜默截斷 ID，導致認證失敗。W3C 規格沒有定義最大長度，所以 1023 足以容納所有已知的實作。" }
+    ],
+    quiz: [
+      {
+        question: "註冊時，伺服器為什麼必須驗證 clientDataJSON.type === 'webauthn.create'？",
+        options: [
+          "確認瀏覽器使用的是最新版 WebAuthn",
+          "防止跨典禮攻擊——認證回應被重放為註冊回應",
+          "確保驗證器支援請求的演算法",
+          "驗證使用者已授權相機權限進行生物辨識掃描"
+        ],
+        correct: 1,
+        explanation: "type 欄位區分了註冊（'webauthn.create'）和認證（'webauthn.get'）。如果不檢查，攻擊者可以將認證的 assertion 重放為註冊回應，可能綁定攻擊者控制的憑證。這稱為跨典禮攻擊（cross-ceremony attack）。"
+      },
+      {
+        question: "面向消費者的應用程式應該使用哪個 attestation 值？",
+        options: [
+          "attestation: 'direct'——驗證驗證器型號",
+          "attestation: 'enterprise'——最高安全性",
+          "attestation: 'none'——消費者流程不需要證明",
+          "attestation: 'indirect'——保護隱私的證明"
+        ],
+        correct: 2,
+        explanation: "W3C 建議消費者應用使用 'none'。證明（attestation）會揭露驗證器型號，引起隱私疑慮。企業證明用於組織管控（追蹤裝置資產）。對消費者 Passkey 流程來說，無論證明格式如何，憑證的功能完全相同。"
+      }
+    ],
+    sources: [
+      { title: "W3C WebAuthn Level 3 Specification", url: "https://www.w3.org/TR/webauthn-3/" },
+      { title: "MDN: PublicKeyCredentialCreationOptions", url: "https://developer.mozilla.org/en-US/docs/Web/API/PublicKeyCredentialCreationOptions" },
+      { title: "The Copenhagen Book: WebAuthn", url: "https://thecopenhagenbook.com/webauthn" },
+      { title: "MDN: Attestation and Assertion", url: "https://developer.mozilla.org/en-US/docs/Web/API/Web_Authentication_API/Attestation_and_Assertion" }
+    ]
+  };

--- a/docs/course/lessons/lesson-5.js
+++ b/docs/course/lessons/lesson-5.js
@@ -1,0 +1,112 @@
+/* 第 5 課 */
+const LESSON_5 = {
+    id: 5,
+    title: "認證典禮（Assertion）深入解析",
+    difficulty: "intermediate",
+    objectives: [
+      "為可發現式和非可發現式流程建構 PublicKeyCredentialRequestOptions",
+      "實作伺服器端簽章驗證，包括 ES256 的 DER 編碼要求",
+      "說明硬體 Token 與同步 Passkey（signCount=0）的 signCount 邏輯差異",
+      "辨識憑證對使用者綁定的漏洞（CVE-2025-26788 模式）"
+    ],
+    body: `
+      <h3>認證 API</h3>
+      <pre>// 可發現式憑證 / Passkey 流程（不帶 allowCredentials）
+const assertion = await navigator.credentials.get({
+  publicKey: {
+    challenge: newServerChallenge,
+    rpId: "example.com",
+    userVerification: "required",
+    // allowCredentials: [] -- Passkey 流程省略此欄位
+    timeout: 300000
+  }
+});
+
+// 非可發現式 / 2FA 流程
+const assertion = await navigator.credentials.get({
+  publicKey: {
+    challenge: newServerChallenge,
+    rpId: "example.com",
+    allowCredentials: [{
+      type: "public-key",
+      id: storedCredentialId,
+      transports: ["internal", "hybrid"]
+    }]
+  }
+});</pre>
+
+      <h3>認證回應</h3>
+      <p><code>AuthenticatorAssertionResponse</code> 包含四個欄位：</p>
+      <ul>
+        <li><code>clientDataJSON</code>——ArrayBuffer：type、challenge、origin</li>
+        <li><code>authenticatorData</code>——ArrayBuffer：rpIdHash + flags + signCount（不含 attestedCredentialData）</li>
+        <li><code>signature</code>——ArrayBuffer：ECDSA 使用 ASN.1 DER 編碼</li>
+        <li><code>userHandle</code>——ArrayBuffer|null：註冊時的 user.id</li>
+      </ul>
+
+      <h3>簽章驗證</h3>
+      <pre>// 被簽署的資料：
+const signedData = concat(authenticatorData, SHA256(clientDataJSON));
+
+// Node.js 中驗證 ES256：
+const isValid = crypto.createVerify("SHA256")
+  .update(signedData)
+  .verify(
+    { key: storedPublicKey, dsaEncoding: "der" },
+    signature
+  );</pre>
+
+      <h3>伺服器端驗證檢查清單（8 個步驟）</h3>
+      <ol>
+        <li>用 rawId / credential ID 查找已儲存的憑證</li>
+        <li>驗證 <code>clientDataJSON.type === "webauthn.get"</code></li>
+        <li>驗證挑戰一致且已消耗（單次使用、立即作廢）</li>
+        <li>驗證 origin 精確比對</li>
+        <li>驗證 rpIdHash 等於設定的 RP ID 的 SHA-256</li>
+        <li>檢查 flags：UP 必須設定；UV 若有要求也必須設定</li>
+        <li>用已儲存的公鑰驗證簽章</li>
+        <li>更新 signCount</li>
+      </ol>
+
+      <div class="callout-critical callout"><strong>重要：憑證對使用者的綁定。</strong>你必須驗證這個憑證「屬於」正在認證的使用者——不只是簽章有效就好。CVE-2025-26788（StrongKey FIDO Server）因為伺服器只檢查簽章有效性，卻沒有確認憑證是否屬於聲稱的使用者，導致了完整的帳號接管。</div>
+
+      <h3>signCount 邏輯</h3>
+      <p>硬體 Token 在每次認證時都會遞增 signCount。如果新的計數沒有嚴格大於已儲存的計數，驗證器可能已被複製。<strong>但是</strong>：同步 Passkeys 每次都回傳 signCount=0。規則如下：</p>
+      <pre>if (storedCount !== 0 || responseCount !== 0) {
+  if (responseCount &lt;= storedCount) {
+    throw new Error("可能是被複製的驗證器");
+  }
+}
+// 兩者都是 0？接受——該憑證的複製偵測已停用</pre>
+
+      <h3>升級認證（Step-Up Authentication）</h3>
+      <p>對於敏感操作（變更密碼、付款），無論現有 session 狀態如何，都觸發一次新的 WebAuthn 典禮。用時間戳記來防護：</p>
+      <pre>if (!session.stepUpUntil || Date.now() > session.stepUpUntil) {
+  return redirectToWebAuthnChallenge();
+}</pre>
+    `,
+    flashcards: [
+      { front: "什麼是憑證對使用者綁定的漏洞？", back: "CVE-2025-26788 模式：伺服器驗證簽章在加密學上是有效的，但沒有確認該憑證屬於正在認證的使用者。攻擊者可以在請求中替換自己的 credential ID，用自己的金鑰通過簽章驗證，從而取得受害者帳號的存取權。大約一半的自行實作都遺漏了這個檢查。" },
+      { front: "signCount 在同步 Passkey 和硬體 Token 上有什麼不同？", back: "硬體 Token 每次認證時遞增 signCount——如果新計數沒有大於已儲存的，Token 可能被複製了。同步 Passkeys 永遠回傳 signCount=0，因為多個裝置合法地共享同一個憑證。當已儲存和回應的計數都是 0 時，直接接受（該憑證的複製偵測已停用）。" },
+      { front: "為什麼挑戰必須立即消耗？", back: "挑戰必須在首次使用後立即作廢，即使驗證失敗也一樣。延遲消耗會開啟一個重放窗口，攻擊者可以在挑戰過期前重放捕獲到的回應。使用原子性的消耗並刪除語義（例如 Redis DEL 只會成功回傳一次）。" }
+    ],
+    quiz: [
+      {
+        question: "CVE-2025-26788 對 WebAuthn 伺服器實作有什麼啟示？",
+        options: [
+          "WebAuthn 簽章可以用足夠的算力偽造",
+          "伺服器必須驗證憑證屬於聲稱的使用者，不只是簽章有效就好",
+          "ECDSA 簽章比 RSA 不安全",
+          "signCount 必須永遠大於零"
+        ],
+        correct: 1,
+        explanation: "CVE-2025-26788（StrongKey FIDO Server）證明了僅驗證加密簽章是不夠的。伺服器還必須確認 credential ID 確實與嘗試認證的使用者相關聯。缺少這個綁定檢查，攻擊者可以註冊自己的憑證，然後用它以任何使用者的身分進行認證。"
+      }
+    ],
+    sources: [
+      { title: "W3C WebAuthn Level 3: Assertion", url: "https://www.w3.org/TR/webauthn-3/#sctn-verifying-assertion" },
+      { title: "MDN: navigator.credentials.get()", url: "https://developer.mozilla.org/en-US/docs/Web/API/CredentialsContainer/get" },
+      { title: "The Copenhagen Book: WebAuthn Verification", url: "https://thecopenhagenbook.com/webauthn" },
+      { title: "WorkOS: Cryptographic Origin Binding", url: "https://workos.com/blog/cryptographic-origin-binding" }
+    ]
+  };

--- a/docs/course/lessons/lesson-6.js
+++ b/docs/course/lessons/lesson-6.js
@@ -1,0 +1,104 @@
+/* 第 6 課 */
+const LESSON_6 = {
+    id: 6,
+    title: "Passkeys、Conditional UI 與實作",
+    difficulty: "intermediate",
+    objectives: [
+      "區分同步 Passkeys（BE=1/BS=1）與裝置綁定憑證，並說明同步架構",
+      "實作 Conditional UI（Passkey 自動填入）並搭配正確的 AbortController 生命週期",
+      "選擇並使用伺服器端函式庫（SimpleWebAuthn、py_webauthn 等）進行註冊和認證",
+      "設計用於生產環境 Passkey 部署的資料庫架構和挑戰儲存機制"
+    ],
+    body: `
+      <h3>什麼是 Passkeys？</h3>
+      <p>Passkey 是一種 WebAuthn 可發現式憑證，透過端對端加密的雲端服務在使用者的裝置間同步。技術上透過 authenticatorData 中的 <code>BE</code>（Backup Eligibility）和 <code>BS</code>（Backup State）旗標都設為 1 來識別。</p>
+
+      <h3>同步架構</h3>
+      <ul>
+        <li><strong>iCloud 鑰匙圈</strong>——加密金鑰來自 Secure Enclave，透過 iCloud Secure Sync 託管，端對端加密（Apple 無法讀取）</li>
+        <li><strong>Google 密碼管理器</strong>——加密金鑰來自螢幕鎖定憑證，託管在搭載 Titan HSM 的 Cloud Key Vault 中</li>
+        <li><strong>第三方</strong>（1Password、Bitwarden、Dashlane）——在 Android 14+ 和 Windows 11 25H2+ 上作為 CTAP2 提供者</li>
+      </ul>
+      <div class="callout">同步 Passkeys 的攻擊向量是同步帳號（Apple ID、Google 帳號）的帳號接管，而不是 Passkey 加密本身。</div>
+
+      <h3>Conditional UI（Passkey 自動填入）</h3>
+      <pre>&lt;!-- HTML：autocomplete 的 token 必須放在最後 --&gt;
+&lt;input type="text" id="username" autocomplete="username webauthn"&gt;</pre>
+      <pre>// JavaScript：在頁面載入時呼叫，不是在按鈕點擊時
+async function initPasskeyAutofill() {
+  if (!await PublicKeyCredential.isConditionalMediationAvailable())
+    return;
+
+  const options = await fetch("/auth/login/options").then(r => r.json());
+
+  // SPA 路由切換時用 AbortController
+  window.autofillController?.abort();
+  window.autofillController = new AbortController();
+
+  const assertion = await navigator.credentials.get({
+    publicKey: PublicKeyCredential.parseRequestOptionsFromJSON(options),
+    mediation: "conditional",
+    signal: window.autofillController.signal
+  });
+
+  await fetch("/auth/login/verify", {
+    method: "POST",
+    body: JSON.stringify(assertion.toJSON())
+  });
+}</pre>
+
+      <h3>伺服器端函式庫</h3>
+      <ul>
+        <li><strong>SimpleWebAuthn</strong>（TypeScript）——<code>generateRegistrationOptions()</code>、<code>verifyRegistrationResponse()</code>、<code>generateAuthenticationOptions()</code>、<code>verifyAuthenticationResponse()</code></li>
+        <li><strong>py_webauthn</strong>（Python）——<code>generate_registration_options()</code>、<code>verify_registration_response()</code></li>
+        <li><strong>webauthn-rs</strong>（Rust）——<code>start_passkey_registration()</code> / <code>finish_passkey_registration()</code></li>
+        <li><strong>java-webauthn-server</strong>（Java/Yubico）——<code>startRegistration()</code> / <code>finishRegistration()</code></li>
+        <li><strong>fido2-net-lib</strong>（.NET）——<code>RequestNewCredential()</code> / <code>MakeNewCredentialAsync()</code></li>
+        <li><strong>go-webauthn</strong>（Go）——<code>BeginRegistration()</code> / <code>FinishRegistration()</code></li>
+        <li><strong>webauthn-ruby</strong>（Ruby）——<code>WebAuthn::Credential.options_for_create()</code> / <code>.from_create().verify()</code></li>
+      </ul>
+
+      <h3>挑戰儲存</h3>
+      <div class="callout-critical callout"><strong>絕對不要把挑戰存在 JWT 或未綁定的 Cookie 中。</strong>挑戰必須存在伺服器端（Redis 或資料庫），搭配 TTL 和原子性的消耗並刪除語義。這是 WebAuthn 實作中最常見的架構錯誤。</div>
+      <pre>-- pending_challenges 資料表
+challenge     BYTEA PRIMARY KEY
+user_id       UUID
+purpose       VARCHAR(20)  -- 'registration' 或 'authentication'
+expires_at    TIMESTAMPTZ  -- NOW() + INTERVAL '5 minutes'</pre>
+    `,
+    flashcards: [
+      { front: "Conditional UI 的 navigator.credentials.get() 應該什麼時候呼叫？", back: "在頁面載入時呼叫，不是在按鈕點擊時。conditional 的 get() 呼叫會無限期掛起，直到使用者從自動填入下拉選單中選取一個 Passkey。如果在按鈕點擊時才呼叫，自動填入建議要到點擊後才會出現，那就變成一般的 modal 流程了，失去了 Conditional UI 的意義。" },
+      { front: "為什麼挑戰絕對不能存在 JWT 中？", back: "JWT 是無狀態的——伺服器無法在首次使用後讓它失效。存在 JWT 中的挑戰會一直有效到 JWT 過期為止，產生重放攻擊的窗口。挑戰必須存在伺服器端（Redis 或 DB），並在首次驗證嘗試後立即、原子性地作廢，無論驗證成功還是失敗。" },
+      { front: "什麼是 Credential Exchange Protocol（CXP）？", back: "FIDO 聯盟的規格（2024 年 10 月），實現端對端加密的跨提供者 Passkey 轉移。不像 CSV 匯出，憑證在轉移過程中永遠不會以明文存在。Apple iOS 26 是第一個主要的實作。CXP 消除了 Passkey 採用的首要反對意見：供應商鎖定。" }
+    ],
+    quiz: [
+      {
+        question: "Conditional UI（Passkey 自動填入）需要哪個 HTML 屬性？",
+        options: [
+          "data-passkey=\"autofill\"",
+          "autocomplete=\"username webauthn\"（webauthn 必須是最後一個 token）",
+          "role=\"passkey-input\"",
+          "type=\"passkey\""
+        ],
+        correct: 1,
+        explanation: "autocomplete 屬性必須包含 'webauthn' 作為最後一個 token：autocomplete='username webauthn'。這告訴瀏覽器在自動填入下拉選單中，除了已儲存的密碼外，也要顯示已儲存的 Passkeys。瀏覽器會檢查這個 token 才啟用 conditional mediation。"
+      },
+      {
+        question: "WebAuthn 伺服器實作中最常見的架構錯誤是什麼？",
+        options: [
+          "使用 ES256 而不是 RS256",
+          "把挑戰存在 JWT 或未綁定的 Cookie 中，而不是存在伺服器端",
+          "沒有實作證明（attestation）驗證",
+          "使用 base64 而不是 base64url 編碼"
+        ],
+        correct: 1,
+        explanation: "把挑戰存在 JWT 或 Cookie 中是最常見的錯誤，因為 JWT 是無狀態的——伺服器無法在使用後讓它失效。這會產生重放攻擊的窗口。挑戰必須存在伺服器端（Redis、資料庫），搭配 TTL 和原子性的消耗並刪除語義。"
+      }
+    ],
+    sources: [
+      { title: "passkeys.dev — Developer Reference", url: "https://passkeys.dev/" },
+      { title: "SimpleWebAuthn Documentation", url: "https://simplewebauthn.dev/" },
+      { title: "Corbado: Conditional UI / Passkey Autofill", url: "https://www.corbado.com/blog/webauthn-conditional-ui-passkeys-autofill" },
+      { title: "FIDO Alliance: Credential Exchange Protocol", url: "https://fidoalliance.org/specifications/" }
+    ]
+  };

--- a/docs/course/lessons/lesson-7.js
+++ b/docs/course/lessons/lesson-7.js
@@ -1,0 +1,97 @@
+/* 第 7 課 */
+const LESSON_7 = {
+    id: 7,
+    title: "安全性、UX 設計與瀏覽器相容性",
+    difficulty: "advanced",
+    objectives: [
+      "說明 WebAuthn 防釣魚的兩層保護：rpIdHash 綁定和 origin 綁定",
+      "辨識真實世界的攻擊向量：DEF CON 33 提示欺騙、瀏覽器擴充功能劫持、CVE 漏洞",
+      "應用 UX 設計模式：觸發式註冊、漸進式採用和無障礙設計",
+      "掌握瀏覽器/平台相容性矩陣，包括關鍵缺口（Windows 10、Linux、Android NFC）"
+    ],
+    body: `
+      <h3>兩層防釣魚保護</h3>
+      <p><strong>第一層——rpIdHash：</strong>authenticatorData 的前 32 位元組是 RP ID 的 SHA-256。在 'bank.com' 註冊的憑證無法在 'evil-bank.com' 使用，因為 rpIdHash 不會匹配。這由驗證器強制執行。</p>
+      <p><strong>第二層——Origin 綁定：</strong>瀏覽器獨立捕捉完整的來源（scheme+host+port）到 clientDataJSON 中。這個值來自瀏覽器的導航上下文，無法被 JavaScript 覆寫。伺服器會將它與允許清單比對。</p>
+      <p>AiTM 代理為什麼會失敗：代理的 origin 被記錄到 clientDataJSON 中，而不是合法網站的 origin。伺服器會拒絕。</p>
+
+      <h3>已知的攻擊向量</h3>
+      <ul>
+        <li><strong>DEF CON 33（2025 年 8 月）：</strong>針對同步 Passkeys 的 UI 層級提示欺騙——精確到像素的 OS 對話框仿製品，在活躍的 session 中攔截使用者。對硬體安全晶片中的裝置綁定 Passkeys 無效。</li>
+        <li><strong>SquareX（DEF CON 2025）：</strong>惡意瀏覽器擴充功能在驗證器「看到」之前就劫持了 WebAuthn API，產生攻擊者控制的金鑰對。這是瀏覽器安全問題，不是協定漏洞。</li>
+        <li><strong>CVE-2024-9956</strong>（Chrome Android）：藍牙範圍內的攻擊者透過 FIDO:/ URI 處理觸發未經使用者互動的未授權 Passkey 認證。</li>
+        <li><strong>CVE-2025-26788</strong>（StrongKey）：缺少憑證對使用者的綁定檢查，允許完整的帳號接管。</li>
+      </ul>
+
+      <h3>五個最常見的伺服器端邏輯缺陷</h3>
+      <ol>
+        <li>可預測或可重複使用的挑戰</li>
+        <li>缺少憑證對使用者的綁定</li>
+        <li>演算法混淆（沒檢查 COSE 演算法是否與註冊時一致）</li>
+        <li>跳過 origin 或 rpIdHash 驗證</li>
+        <li>缺少 UP/UV 旗標檢查</li>
+      </ol>
+
+      <h3>UX 設計模式</h3>
+      <ul>
+        <li><strong>觸發式註冊</strong>——在密碼登入成功後立即自動提示。eBay 相比將選項藏在設定頁面中，獲得了 102% 的採用率提升。</li>
+        <li><strong>便利性導向的文案</strong>——「簡化你的登入」比安全性訊息更有效。Google 發現「建立 Passkey」比「新增 Passkey」更好。</li>
+        <li><strong>靜默轉換</strong>——在不需要使用者操作的情況下，從已儲存的密碼建立 Passkeys（Roblox 手機端 50%、TikTok iOS）。</li>
+        <li><strong>管理介面</strong>——每個 Passkey 的卡片，顯示建立日期、生態系來源（AAGUID 查詢）、最後使用時間、刪除選項。</li>
+      </ul>
+      <div class="callout">在沒有 Passkey 管理介面的情況下就推出 Passkey 註冊是反模式——會讓使用者覺得被困住了。FIDO 聯盟要求同時提供建立和管理兩種設計模式。</div>
+
+      <h3>瀏覽器/平台相容性</h3>
+      <ul>
+        <li><strong>Windows 10：</strong>不支援 Conditional UI、不支援 PRF——最大的企業缺口</li>
+        <li><strong>Linux：</strong>沒有原生平台驗證器——只能用混合 QR 或硬體金鑰</li>
+        <li><strong>Android NFC：</strong>不支援透過 NFC 的 CTAP2（Android 上無法透過 NFC 使用可發現式憑證）</li>
+        <li><strong>Safari：</strong>Safari 17.3 及更早版本中，create()/get() 必須在原生 click handler 內呼叫</li>
+        <li><strong>Firefox Android：</strong>歷史上問題較多；部署前務必明確測試</li>
+        <li><strong>全球 WebAuthn 覆蓋率：</strong>94.05%；Passkeys 特定覆蓋率：91.04%</li>
+      </ul>
+
+      <h3>生產環境實績</h3>
+      <ul>
+        <li>Google：設為預設後 Passkey 增長 352%</li>
+        <li>TikTok：90%+ 成功率，比 Email OTP 快 20 倍</li>
+        <li>Uber：認證速度快 5 倍，成功率高 2 倍</li>
+        <li>DocuSign：99% 成功率，部署超過 1100 萬個 Passkeys</li>
+      </ul>
+    `,
+    flashcards: [
+      { front: "為什麼 AiTM（中間人代理）攻擊對 WebAuthn 無效？", back: "瀏覽器從它的導航上下文中獨立記錄完整的 origin（scheme+host+port）到 clientDataJSON——JavaScript 無法覆寫這個值。當使用者在釣魚代理上時，代理的 origin 會被記錄，而不是合法網站的。伺服器的 origin 檢查會拒絕該請求。此外，代理的 rpIdHash 也不存在對應的憑證。" },
+      { front: "什麼是觸發式註冊？為什麼它很有效？", back: "觸發式註冊是在密碼登入成功後立即自動提示建立 Passkey。eBay 相比將選項藏在帳號設定中，獲得了 102% 的採用率提升。它之所以有效，是因為使用者正處於安全意識狀態、裝置在手邊、而且剛剛證明了自己的身分。75% 的新 Passkey 註冊來自觸發式提示。" },
+      { front: "2026 年 Passkeys 的關鍵平台缺口有哪些？", back: "Windows 10：不支援 Conditional UI 或 PRF。Linux：沒有原生平台驗證器（只能用 QR/混合或硬體金鑰）。Android：不支援透過 NFC 的 CTAP2（打破了 NFC 安全金鑰的預期）。Safari 17.3 及更早版本：需要在原生 click handler 內呼叫。Firefox Android：歷史上不穩定，務必明確測試。" }
+    ],
+    quiz: [
+      {
+        question: "DEF CON 33 的 Passkey 提示欺騙攻擊是怎麼運作的？",
+        options: [
+          "破解 WebAuthn 加密協定",
+          "顯示精確到像素的假 OS 對話框來攔截使用者的生物辨識，只對同步 Passkeys 有效",
+          "利用 CTAP2 藍牙傳輸中的漏洞",
+          "注入惡意 JavaScript 來覆寫 navigator.credentials"
+        ],
+        correct: 1,
+        explanation: "Allthenticate 在 DEF CON 33 的研究展示了 UI 層級的提示欺騙：一個精確到像素的 OS Passkey 對話框仿製品，在活躍的 session 中攔截使用者。這不是協定層級的攻擊——WebAuthn 的加密學是完整的。它對硬體安全晶片中的裝置綁定 Passkeys 無效，因為真正的安全晶片對話框無法在 OS 層級被仿製。"
+      },
+      {
+        question: "什麼單一 UX 改變讓 eBay 的 Passkey 採用率增加了 102%？",
+        options: [
+          "重新設計 Passkey 管理頁面",
+          "在密碼登入成功後立即自動提示建立 Passkey（觸發式註冊）",
+          "發送關於 Passkey 好處的電子郵件行銷活動",
+          "強制所有新帳號使用 Passkeys"
+        ],
+        correct: 1,
+        explanation: "觸發式註冊——在密碼登入成功後立即呈現 Passkey 建立提示——帶來了 102% 的採用率增長。時機是關鍵：使用者處於認證情境中、剛剛證明了身分、裝置也在手邊。這個單一的提示改變佔了所有新 Passkey 註冊的 75%。"
+      }
+    ],
+    sources: [
+      { title: "WorkOS: Cryptographic Origin Binding", url: "https://workos.com/blog/cryptographic-origin-binding" },
+      { title: "Passkey Central — FIDO UX Guidelines", url: "https://passkeycentral.org/" },
+      { title: "Can I Use: WebAuthn", url: "https://caniuse.com/webauthn" },
+      { title: "passkeys.dev: Device Support", url: "https://passkeys.dev/device-support/" }
+    ]
+  };

--- a/docs/course/lessons/lesson-8.js
+++ b/docs/course/lessons/lesson-8.js
@@ -1,0 +1,117 @@
+/* 第 8 課 */
+const LESSON_8 = {
+    id: 8,
+    title: "企業部署、進階擴充與未來趨勢",
+    difficulty: "advanced",
+    objectives: [
+      "使用 Crawl-Walk-Run 框架設計 IDP 中介的企業 Passkey 部署方案",
+      "實作 PRF 擴充以達成硬體支援的端對端加密，以及 Signal API 進行憑證生命週期管理",
+      "設定 Related Origin Requests 以實現跨網域 Passkey 共享",
+      "評估後量子威脅、Digital Credentials API，以及 FIDO 代理式認證倡議"
+    ],
+    body: `
+      <h3>企業部署</h3>
+      <p>2026 年，87% 的企業正在部署或試行 FIDO2 Passkeys。正確的架構模式是<strong>IDP 中介</strong>：Passkeys 透過 Okta、Microsoft Entra ID、Auth0 認證——不是直接對每個應用程式。</p>
+      <p><strong>Crawl-Walk-Run 框架：</strong></p>
+      <ol>
+        <li><strong>Crawl（爬）：</strong>多協定智慧卡 + 憑證式認證（CBA）</li>
+        <li><strong>Walk（走）：</strong>App 式 MFA，逐步減少對密碼的依賴</li>
+        <li><strong>Run（跑）：</strong>完整的 Passkey 部署搭配 Conditional Access 強制執行</li>
+      </ol>
+      <p><strong>引導悖論（bootstrapping paradox）：</strong>新員工無法在沒有強認證的情況下註冊 Passkey，但他們還沒有任何憑證。解決方案：Temporary Access Pass（TAP）——Microsoft Entra ID 的時效性一次性密碼，透過 Graph API 自動化。</p>
+      <p><strong>混合模式：</strong>47% 的企業結合同步 Passkeys（AAL2，一般員工）和裝置綁定 Passkeys（AAL3，特權/管理員角色）。</p>
+
+      <h3>PRF 擴充</h3>
+      <p>PRF（Pseudo-Random Function）擴充從硬體綁定的金鑰 + RP 提供的鹽值中推導出一個確定性的 32 位元組秘密。這實現了網頁應用中的<strong>硬體支援端對端加密</strong>：</p>
+      <pre>// 註冊：啟用 PRF
+extensions: { prf: {} }
+
+// 認證：推導加密金鑰
+extensions: {
+  prf: {
+    eval: {
+      first: new TextEncoder().encode("encryption-salt-v1")
+    }
+  }
+}
+
+// 將 PRF 輸出作為 Input Keying Material（IKM）
+const prfOutput = assertion.getClientExtensionResults().prf.results.first;
+const ikm = await crypto.subtle.importKey(
+  "raw", prfOutput, "HKDF", false, ["deriveKey"]);
+const aesKey = await crypto.subtle.deriveKey(
+  { name: "HKDF", hash: "SHA-256",
+    salt: new Uint8Array(32),
+    info: new TextEncoder().encode("my-app-encryption") },
+  ikm, { name: "AES-GCM", length: 256 }, false,
+  ["encrypt", "decrypt"]
+);</pre>
+      <p>Bitwarden 就使用這個模式：Data Encryption Keys（DEK）用每個憑證的 Key Encryption Keys（KEK）包裹。任何已註冊的 Passkey 都可以解包保險庫。</p>
+
+      <h3>Signal API</h3>
+      <p>三個方法用來通知 Passkey 提供者憑證狀態的變更：</p>
+      <ul>
+        <li><code>PublicKeyCredential.signalAllAcceptedCredentials({rpId, userId, allAcceptedCredentialIds})</code>——回報完整的有效憑證清單（每次認證後都要呼叫）</li>
+        <li><code>PublicKeyCredential.signalUnknownCredential({rpId, credentialId})</code>——回報無法識別的憑證</li>
+        <li><code>PublicKeyCredential.signalCurrentUserDetails({rpId, userId, name, displayName})</code>——更新使用者中繼資料</li>
+      </ul>
+      <div class="callout-critical callout">signalAllAcceptedCredentials：遺漏有效的 ID 會導致鎖定。你必須傳送該使用者所有有效 credential ID 的完整清單。</div>
+
+      <h3>Related Origin Requests（ROR）</h3>
+      <p>讓單一 Passkey 跨多個網域使用。主要網域提供 <code>/.well-known/webauthn</code>：</p>
+      <pre>// https://example.com/.well-known/webauthn
+{
+  "origins": [
+    "https://app.example.com",
+    "https://example.de",
+    "https://example.co.uk"
+  ]
+}
+// 硬性限制：最多 5 個不同的 eTLD+1 標籤
+// rpId 本身不可以出現在清單中</pre>
+
+      <h3>未來趨勢</h3>
+      <ul>
+        <li><strong>Digital Credentials API</strong>——<code>navigator.credentials.get()</code> 擴充用於從身分錢包取得可驗證憑證。Chrome 141 正式版（2025 年 10 月）。Passkeys 認證身分；VCs 證明屬性（年齡、資格）。</li>
+        <li><strong>歐盟 eIDAS 2.0</strong>——每個成員國必須在 2026 年 12 月 31 日前提供數位身分錢包，使用 CTAP 2.2 混合流程。</li>
+        <li><strong>代理式認證（Agentic Authentication）</strong>——FIDO 聯盟 TWG（2026 年 4 月）：為 AI 代理認證制定標準，由 CVS Health、Google 和 OpenAI 共同主持。預計 2030 年代理式商務規模達 5 兆美元。</li>
+        <li><strong>後量子加密</strong>——ML-DSA（Module-Lattice Digital Signature）於 2025 年 4 月加入 IANA COSE 註冊表。Google 的第一把量子抵抗 FIDO2 金鑰：ECDSA + Dilithium 混合（2023 年 8 月）。現在就要建構演算法敏捷架構。</li>
+        <li><strong>市場規模</strong>——無密碼認證：2025 年 241 億美元，預計 2030 年達 557 億美元（年複合成長率 18.24%）。</li>
+      </ul>
+    `,
+    flashcards: [
+      { front: "PRF 擴充能實現什麼？", back: "在網頁應用中實現硬體支援的端對端加密。PRF 用硬體綁定的秘密 + RP 提供的鹽值執行 HMAC，產生一個確定性的 32 位元組輸出。這個輸出再透過 HKDF 推導出 AES 金鑰。秘密永遠不會離開驗證器。Bitwarden 就用這個模式來實現零知識的保險庫加密。" },
+      { front: "企業 Passkey 部署中的引導悖論是什麼？", back: "新員工需要強認證才能註冊他們的第一個 Passkey，但他們還沒有任何憑證。解決方案：Temporary Access Pass（TAP）——Microsoft Entra ID 的時效性一次性密碼。必須透過 Graph API 大規模自動化（isUsableOnce: true），並在首次使用後立即作廢。" },
+      { front: "FIDO 代理式認證倡議是什麼？", back: "FIDO 聯盟的技術工作小組（2026 年 4 月），由 CVS Health、Google 和 OpenAI 共同主持，為 AI 代理認證制定標準。三個工作流：可驗證使用者指令、代理認證、以及商務受信委託。針對預計 2030 年達 5 兆美元的代理式商務市場。" }
+    ],
+    quiz: [
+      {
+        question: "正確的企業 Passkey 架構模式是什麼？",
+        options: [
+          "每個應用程式各自實作自己的 WebAuthn 伺服器",
+          "IDP 中介：透過 Okta/Entra ID/Auth0 認證，再透過 SSO 發放 token 給下游應用",
+          "一個集中式的 WebAuthn 代理攔截所有認證請求",
+          "客戶端使用 Web Crypto API 進行 Passkey 驗證"
+        ],
+        correct: 1,
+        explanation: "IDP 中介架構是正確的企業模式：Passkeys 在身分提供者（Okta、Microsoft Entra ID、Auth0）處認證，再由其發放 OIDC token 或 SAML assertion 給下游應用透過 SSO 存取。直接的 RP 對驗證器 Passkeys 無法擴展到數百個企業應用。"
+      },
+      {
+        question: "PRF 擴充的輸出在用作加密金鑰之前需要什麼處理？",
+        options: [
+          "Base64 編碼將它轉成字串",
+          "HKDF（RFC 5869）金鑰推導以產生正確的 AES 金鑰材料",
+          "不需要處理——32 位元組輸出可直接作為 AES-256 金鑰使用",
+          "RSA 包裹以在傳輸中保護金鑰"
+        ],
+        correct: 1,
+        explanation: "PRF 的輸出是 Input Keying Material（IKM），不是最終金鑰。它必須透過 HKDF（RFC 5869）搭配域別資訊字串處理後，才能作為 AES 金鑰材料使用。直接使用原始 PRF 輸出會跳過提供域別分離和正確金鑰格式化的金鑰推導步驟。"
+      }
+    ],
+    sources: [
+      { title: "W3C WebAuthn Level 3: Extensions", url: "https://www.w3.org/TR/webauthn-3/#sctn-defined-extensions" },
+      { title: "FIDO Alliance: Agentic Authentication TWG", url: "https://fidoalliance.org/" },
+      { title: "Microsoft: Passwordless Deployment Guide", url: "https://learn.microsoft.com/en-us/entra/identity/authentication/howto-authentication-passwordless-deployment" },
+      { title: "W3C Digital Credentials API", url: "https://wicg.github.io/digital-credentials/" }
+    ]
+  };

--- a/docs/course/lessons/review.js
+++ b/docs/course/lessons/review.js
@@ -1,0 +1,95 @@
+/* 總複習測驗與參考資料 */
+const REVIEW_QUESTIONS = [
+  {
+    question: "FIDO2 標準由哪兩個元件組成？",
+    options: [
+      "WebAuthn（瀏覽器 API）和 CTAP2（驗證器協定）",
+      "OAuth 2.0 和 OpenID Connect",
+      "TLS 和 X.509 憑證",
+      "SAML 和 Kerberos"
+    ],
+    correct: 0,
+    explanation: "FIDO2 = WebAuthn（W3C 瀏覽器 JavaScript API，用於瀏覽器到伺服器的通訊）+ CTAP2（FIDO 聯盟的 Client-to-Authenticator Protocol，用於瀏覽器/OS 到驗證器的通訊，透過 USB、NFC 或藍牙）。"
+  },
+  {
+    question: "attestationObject 和 credentialPublicKey 使用什麼二進位格式編碼？",
+    options: ["JSON", "Protocol Buffers", "CBOR（Concise Binary Object Representation）", "MessagePack"],
+    correct: 2,
+    explanation: "WebAuthn 使用 CBOR（RFC 8949）來編碼 attestationObject 和 COSE 金鑰，因為它比 JSON 小 20-50%，且原生支援二進位資料，這對頻寬受限的 NFC/BLE 驗證器通道至關重要。"
+  },
+  {
+    question: "認證典禮中，驗證器簽署了什麼資料？",
+    options: [
+      "只有挑戰（challenge）的位元組",
+      "concat(authenticatorData, SHA-256(clientDataJSON))",
+      "使用者 ID 和密碼雜湊",
+      "驗證器自行產生的隨機 nonce"
+    ],
+    correct: 1,
+    explanation: "被簽署的資料是 concat(authenticatorData, SHA-256(clientDataJSON))。這將 rpIdHash（防釣魚保護）、flags（UP/UV）、signCount，以及來自 clientDataJSON 的 challenge + origin 全部綁定在一個不可偽造的簽章中。"
+  },
+  {
+    question: "在 authenticatorData 中，什麼區分了同步 Passkey 和裝置綁定憑證？",
+    options: [
+      "signCount 永遠大於 1000",
+      "AAGUID 被設為全零",
+      "BE（Backup Eligible）和 BS（Backup State）旗標都被設為 1",
+      "UV（User Verified）旗標未被設定"
+    ],
+    correct: 2,
+    explanation: "同步 Passkeys 的 BE=1（位元 3，0x08：憑證可以同步）和 BS=1（位元 4，0x10：憑證目前已備份）。裝置綁定憑證的 BE=0, BS=0。這些旗標應該存到資料庫中以便制定安全策略決策。"
+  },
+  {
+    question: "為什麼 Conditional UI 的 get() 呼叫需要在頁面載入時發起？",
+    options: [
+      "因為瀏覽器需要時間載入 CTAP2 驅動程式",
+      "因為 Promise 會一直掛起直到使用者從自動填入中選取——在點擊時呼叫就失去了自動填入的 UX 意義",
+      "因為 WebAuthn 需要 5 秒的暖機時間",
+      "因為挑戰在產生後立即過期"
+    ],
+    correct: 1,
+    explanation: "conditional 的 get() Promise 會無限期掛起，直到使用者從自動填入下拉選單中選取一個 Passkey。如果在按鈕點擊時才呼叫，自動填入建議要到點擊後才會出現，那就變成一般的 modal 流程了。重點是要在已儲存的密碼旁邊自動顯示 Passkeys。"
+  },
+  {
+    question: "同步 Passkeys 的主要攻擊面是什麼？",
+    options: [
+      "破解 ECDSA P-256 演算法",
+      "同步帳號（Apple ID、Google 帳號）的帳號接管",
+      "在混合認證期間攔截藍牙通訊",
+      "複製驗證器硬體"
+    ],
+    correct: 1,
+    explanation: "同步架構（iCloud 鑰匙圈、Google 密碼管理器）才是真正的攻擊面。Passkey 的加密學是健全的，但如果攻擊者接管了同步帳號，就能存取所有同步的 Passkeys。這就是為什麼帳號復原設計需要和認證設計一樣嚴謹的安全考量。"
+  },
+  {
+    question: "PRF 擴充的輸出在用作 AES 加密金鑰前需要什麼處理？",
+    options: [
+      "直接使用——32 位元組輸出就是有效的 AES-256 金鑰",
+      "Base64url 編碼",
+      "HKDF 金鑰推導（RFC 5869）搭配域別資訊",
+      "RSA 加密包裹"
+    ],
+    correct: 2,
+    explanation: "PRF 輸出是 Input Keying Material（IKM），不是最終金鑰。它必須透過 HKDF 搭配域別資訊字串處理後才能推導出正確的 AES 金鑰材料。直接使用會跳過域別分離和正確的金鑰格式化。"
+  },
+  {
+    question: "大規模部署 Passkey 的正確企業架構是什麼？",
+    options: [
+      "每個應用程式各自執行自己的 WebAuthn 伺服器",
+      "IDP 中介：在 Okta/Entra ID/Auth0 認證，透過 SSO 發放 OIDC/SAML token 給應用",
+      "客戶端用 JavaScript 做 WebAuthn 驗證",
+      "跨應用共享的私鑰資料庫"
+    ],
+    correct: 1,
+    explanation: "IDP 中介模式是正確的：Passkeys 在身分提供者處認證，再由其發放標準化的 token（OIDC/SAML）給下游應用。直接的 RP 實作無法擴展到數百個企業應用，且會造成難以管理的憑證生命週期複雜性。"
+  }
+];
+
+const OVERVIEW_SOURCES = [
+  { title: "W3C WebAuthn Level 3 — Candidate Recommendation (May 2026)", url: "https://www.w3.org/TR/webauthn-3/" },
+  { title: "FIDO Alliance Specifications & CTAP 2.3", url: "https://fidoalliance.org/specifications/" },
+  { title: "NIST SP 800-63-4 Digital Identity Guidelines (July 2025)", url: "https://pages.nist.gov/800-63-4/" },
+  { title: "passkeys.dev — Developer Reference Hub", url: "https://passkeys.dev/" },
+  { title: "Passkey Central — FIDO UX Design Guidelines", url: "https://passkeycentral.org/" },
+  { title: "MDN: Web Authentication API", url: "https://developer.mozilla.org/en-US/docs/Web/API/Web_Authentication_API" }
+];

--- a/docs/course/research-synthesis.md
+++ b/docs/course/research-synthesis.md
@@ -1,0 +1,497 @@
+# WebAuthn and Passkeys: The Complete Professional Curriculum
+
+## Overview
+This curriculum synthesizes comprehensive research across 13 domains covering every aspect of WebAuthn, Passkeys, FIDO2, and the broader passwordless authentication ecosystem. It is structured as a progressive learning journey from foundational concepts to expert-level implementation, security analysis, and emerging standards. Each module builds on the previous, establishing the theoretical grounding before moving to practical application. By the end of this curriculum, a learner will be capable of architecting, implementing, auditing, and deploying production-grade passkey systems — skills that are increasingly critical as 87% of enterprises deploy FIDO2 and regulatory mandates eliminate legacy MFA globally. The material is drawn from W3C WebAuthn Level 3 (Candidate Recommendation, May 2026), FIDO Alliance specifications through CTAP 2.3, real-world CVE analysis, production deployment case studies from Google, Microsoft, Amazon, eBay, and Roblox, and security research presented at DEF CON 33.
+
+**Total Estimated Hours: 150**
+**Total Topics Researched: 13**
+**Total Key Findings: 176**
+**Total Concepts Documented: 162**
+
+---
+
+## Module 1: The History and Evolution of Web Authentication
+**Difficulty: Beginner**
+
+### Topics
+- The password problem: why passwords fail at scale (77% of hacking breaches involve stolen or weak passwords, Verizon DBIR)
+- Early authentication attempts: username/password, HTTP Basic Auth, session cookies
+- Second-factor authentication (2FA): SMS OTP, TOTP authenticator apps, push notifications
+- Vulnerabilities of each legacy method: SIM swap fraud, SS7 interception, real-time AiTM relay attacks, MFA fatigue
+- FIDO Alliance founding in February 2013 and its mission to reduce reliance on passwords
+- FIDO 1.0 (December 2014): UAF (Universal Authentication Framework) and U2F (Universal Second Factor)
+- FIDO UAF: passwordless biometric authentication using device-generated key pairs
+- FIDO U2F: hardware security keys as second factors alongside passwords
+- The U2F protocol timeline: U2F 1.0 (October 2014), UAF 1.1 (February 2017), U2F 1.2 (July 2017)
+- The transition to FIDO2: joint W3C/FIDO Alliance project, 2018 release
+- WebAuthn becomes official W3C standard in March 2019
+- CTAP1: the backward-compatible name for U2F, allowing legacy U2F devices in FIDO2 flows
+- The passkey era: Apple iOS 16/macOS Ventura (2022), Google accounts (2023), Microsoft default (May 2025)
+- Adoption milestones: 1 billion passkey activations, 15 billion accounts supporting passkeys, 5 billion active passkeys (2026)
+- The regulatory shift: NIST SP 800-63-4 (July 2025) formally recognizing synced passkeys as AAL2-compliant
+- SMS OTP bans: UAE (March 2026 deadline), India (April 2026), Philippines, US USPTO, FINRA
+
+### Key Takeaways
+- Every legacy authentication method has a known, exploitable attack vector; passkeys eliminate entire attack categories by design rather than by mitigation
+- The FIDO Alliance was founded specifically to address the structural failure of passwords, not to improve them
+- The evolution from U2F hardware keys to synced multi-device passkeys represents a decade of iterative standardization
+- Regulatory mandates are now eliminating SMS OTP in financial services globally, making FIDO2 adoption a compliance requirement, not just a security preference
+- Understanding the history is essential for explaining to stakeholders why passkeys are not just 'another MFA method'
+
+### Practical Exercises
+- Perform an AiTM phishing simulation against a TOTP-protected account to viscerally understand why TOTP is not phishing-resistant
+- Audit an existing application's authentication stack and classify each method against NIST SP 800-63-4 AAL levels
+- Register a physical YubiKey as a FIDO U2F token on GitHub and document the experience, then register a passkey and compare the user flows
+- Read CVE records for SIM swap incidents and map the attack steps to understand the structural vulnerability
+- Create a threat model timeline showing which attacks were possible against authentication in 2014, 2019, and 2026
+
+---
+
+## Module 2: Cryptographic Foundations of WebAuthn
+**Difficulty: Beginner**
+
+### Topics
+- Public-key cryptography fundamentals: key pairs, digital signatures, and verification
+- Why asymmetric cryptography eliminates shared secrets from the server
+- Elliptic Curve Digital Signature Algorithm (ECDSA): the P-256 (secp256r1) curve
+- ES256 (COSE ID -7): ECDSA with P-256 and SHA-256, the most widely supported WebAuthn algorithm
+- RSA: RSASSA-PKCS1-v1_5 and RS256 (COSE ID -257) for Windows Hello and legacy devices
+- Edwards-curve Digital Signature Algorithm (EdDSA): Ed25519 and COSE ID -8, supported by YubiKey 5+
+- Algorithm selection strategy: always include ES256 (-7), RS256 (-257), and EdDSA (-8) in pubKeyCredParams
+- SHA-256 hashing: its role in WebAuthn for rpIdHash, clientDataHash, and challenge binding
+- CBOR (Concise Binary Object Representation): RFC 8949, major types (0-7), deterministic encoding
+- Why WebAuthn chose CBOR over JSON: compactness (20-50% smaller), binary data support, bandwidth constraints on NFC/BLE
+- COSE (CBOR Object Signing and Encryption): RFC 8152, RFC 9052, RFC 9053
+- COSE_Key structure: positive integer labels (kty=1, alg=3) and negative integer labels (crv=-1, x=-2, y=-3 for EC2)
+- COSE_Key for ES256: {1:2, 3:-7, -1:1, -2:<x 32 bytes>, -3:<y 32 bytes>}
+- COSE_Key for EdDSA: {1:1, 3:-8, -1:6, -2:<public key 32 bytes>}
+- base64url encoding: URL-safe Base64 without padding, '+' to '-', '/' to '_', strip '='
+- The challenge-response protocol: how random server challenges prevent replay attacks
+- The signature over concat(authenticatorData, SHA-256(clientDataJSON)): what is actually signed and why
+- Hardware secure enclaves: Apple Secure Enclave, Android StrongBox Keymaster, TPM (Trusted Platform Module)
+- Why private keys never leave the secure enclave in hardware-backed implementations
+- HKDF (RFC 5869) for key derivation from PRF extension output
+
+### Key Takeaways
+- The private key never leaves the authenticator — this is a hardware guarantee, not a software promise
+- CBOR encoding is mandatory for the attestationObject and credentialPublicKey; every implementation must include a CBOR library
+- COSE uses negative integer labels for algorithm-specific parameters, which surprises developers unfamiliar with the format
+- ES256 has the broadest platform authenticator support; RS256 exists specifically for Windows 10 Hello compatibility
+- The challenge is the cryptographic heartbeat of the protocol: removing randomness from it collapses security entirely
+
+### Practical Exercises
+- Implement ECDSA P-256 key generation, signing, and verification from scratch in Python using the cryptography library without any WebAuthn library
+- Write a CBOR decoder for the minimal subset needed to parse an attestationObject (fmt, attStmt, authData)
+- Decode a real WebAuthn attestationObject captured from the browser's DevTools network tab using a CBOR tool like cbor.me
+- Parse the binary authenticatorData byte-by-byte: extract rpIdHash, flags, signCount, AAGUID, credentialId, and COSE public key
+- Use the FIDO Alliance's WebAuthn Response Decoder at passkeys.dev/tools to inspect a real credential and trace every field to its spec definition
+
+---
+
+## Module 3: FIDO2 Architecture — WebAuthn, CTAP2, and the Three-Party Model
+**Difficulty: Beginner**
+
+### Topics
+- FIDO2 as the umbrella standard: exactly two components — WebAuthn (W3C) and CTAP2 (FIDO Alliance)
+- The three participants in every FIDO2 flow: Relying Party, Client/Browser, Authenticator
+- The browser as mediator: why the RP and Authenticator never communicate directly
+- WebAuthn scope: browser-to-server communication and the JS API surface
+- CTAP2 scope: browser/OS-to-authenticator communication over USB, NFC, and Bluetooth
+- CTAP2 commands: authenticatorMakeCredential, authenticatorGetAssertion, authenticatorGetInfo, authenticatorClientPIN, authenticatorReset
+- CTAP1 backward compatibility: legacy U2F devices working with FIDO2 browsers
+- CTAP 2.1 additions: Enterprise Attestation, Credential Management API, Bio Enrollment, alwaysUV, minimum PIN length, largeBlobs extension, credProtect extension, HMAC Secret extension
+- CTAP 2.2 additions: Persistent PIN/UV Auth Tokens (PPUATs), enhanced PIN complexity, thirdPartyPayment extension, hmac-secret-mc, hybrid transport formalization, enhanced getInfo metadata
+- CTAP 2.3 (February 2026): multiple data transfer channels for hybrid interactions, BLE as new channel
+- Platform authenticators: Apple Secure Enclave (Touch ID/Face ID), Windows Hello (TPM), Android Biometric (StrongBox)
+- Roaming authenticators: YubiKey, Google Titan Key, Feitian ePass, SoloKey — USB, NFC, BLE
+- Key differences: platform authenticators can sync via cloud; roaming authenticators cannot export private keys
+- AAGUID: Authenticator Attestation Globally Unique Identifier — 16 bytes identifying the authenticator model
+- FIDO Alliance certification program: L1 through L3+ levels, cumulative requirements
+- L1: protocol compliance, vendor questionnaire; L2: Restricted Operating Environment, accredited lab review; L3: physical attack defense, penetration testing; L3+: chip-level smart card defenses
+- FIDO Metadata Service (MDS3): registry of certified authenticators with attestation certificates and security advisories
+- Relationship clarification: FIDO2 is the standard; WebAuthn is the browser API component; Passkeys are the synced credential implementation
+
+### Key Takeaways
+- FIDO2 = WebAuthn + CTAP2; WebAuthn alone does not encompass the full FIDO2 standard
+- The three-party model is fundamental: understanding it prevents common architectural mistakes like assuming the browser is trusted
+- Roaming authenticators provide AAL3 hardware guarantees that synced passkeys cannot match — each has appropriate use cases
+- CTAP 2.1 and 2.2 add enterprise-critical features that are invisible to most consumer developers but essential for regulated deployments
+- The FIDO Alliance certification program is the supply chain verification mechanism for hardware authenticators
+
+### Practical Exercises
+- Draw the complete three-party message flow diagram for both registration and authentication, labeling every message with its protocol (HTTP, CTAP2, internal OS API)
+- Use Wireshark with a USB HID sniffer to capture raw CTAP2 traffic between a browser and a YubiKey during a WebAuthn registration
+- Look up a real AAGUID (e.g., YubiKey 5 NFC) in the FIDO MDS3 API and read its metadata including supported algorithms, attestation CA, and security characteristics
+- Compare the FIDO certification levels for three different authenticators (one L1, one L2, one L3) and explain what additional security each level provides
+- Read the CTAP2.1 specification section on authenticatorMakeCredential and map every parameter to its corresponding WebAuthn PublicKeyCredentialCreationOptions field
+
+---
+
+## Module 4: WebAuthn Registration Ceremony — Deep Dive
+**Difficulty: Intermediate**
+
+### Topics
+- WebAuthn Level 3 specification status: W3C Candidate Recommendation, May 26, 2026
+- The Credential Management API: navigator.credentials as the entry point
+- navigator.credentials.create({publicKey: PublicKeyCredentialCreationOptions}) — full signature
+- PublicKeyCredentialCreationOptions required fields: challenge, rp.name, user.id, user.name, user.displayName, pubKeyCredParams
+- PublicKeyCredentialCreationOptions optional fields: rp.id, attestation, attestationFormats, authenticatorSelection, excludeCredentials, extensions, hints, timeout
+- challenge requirements: minimum 16 bytes entropy (32 recommended), server-generated, cryptographically random, never client-generated
+- rp.id: domain string, must be effective domain or registrable suffix of page origin — not URL, no scheme or port
+- user.id: opaque ArrayBuffer, max 64 bytes, NOT PII — used as a handle, not displayed to user
+- pubKeyCredParams array: ordered by preference, authenticator picks first supported algorithm
+- authenticatorSelection: authenticatorAttachment, residentKey, userVerification
+- The deprecated requireResidentKey boolean — use residentKey instead
+- attestation conveyance: 'none' (default, recommended for consumers), 'indirect', 'direct', 'enterprise'
+- hints array: 'security-key', 'client-device', 'hybrid' — UI guidance, non-binding
+- excludeCredentials: preventing duplicate registration
+- The registration ceremony step-by-step: user action → server challenge → browser create() → user gesture → authenticator key generation → attestation → server storage
+- AuthenticatorAttestationResponse: clientDataJSON, attestationObject, getTransports(), getAuthenticatorData(), getPublicKey(), getPublicKeyAlgorithm()
+- attestationObject CBOR structure: {fmt, attStmt, authData}
+- Attestation formats: 'none', 'packed', 'tpm', 'android-key', 'android-safetynet', 'fido-u2f', 'apple'
+- Attestation types: Basic, Self/Surrogate, AttCA, AnonCA, None
+- clientDataJSON structure: type, challenge, origin, crossOrigin, topOrigin
+- Server-side registration validation: 8-step checklist
+- Database storage schema: credential_id VARCHAR(1023), public_key BYTEA, counter BIGINT, aaguid, device_type, backup_eligible, backup_state, transports
+- Modern JSON serialization: parseCreationOptionsFromJSON(), credential.toJSON()
+
+### Key Takeaways
+- The registration ceremony is a one-way proof: the authenticator proves it can generate a key pair, but the RP stores only the public key — no secret is ever shared
+- Origin must be checked with exact string equality, never substring matching
+- Storing the credential_id as VARCHAR(1023) is a non-obvious but critical requirement
+- The AT flag in authenticatorData must be set during registration — its absence means no credential data was returned
+- parseCreationOptionsFromJSON() and toJSON() eliminate an entire class of base64url encoding bugs
+
+### Practical Exercises
+- Implement a complete registration endpoint from scratch without using a library — manually decode CBOR, parse authenticatorData binary, verify the challenge, and extract the COSE public key
+- Build a registration flow that correctly handles all three attestation formats (none, packed self, packed full)
+- Create a database migration that stores all required credential fields with correct column types
+- Write a test that attempts to register the same credential twice and verifies excludeCredentials rejects the duplicate
+- Inspect a real attestationObject using CBOR decode tools and trace every field to its spec definition
+
+---
+
+## Module 5: WebAuthn Authentication Ceremony — Deep Dive
+**Difficulty: Intermediate**
+
+### Topics
+- navigator.credentials.get({publicKey: PublicKeyCredentialRequestOptions}) — full signature
+- PublicKeyCredentialRequestOptions required and optional fields
+- allowCredentials array: omit for passkey/discoverable flows
+- transports values: 'ble', 'hybrid', 'internal', 'nfc', 'usb', 'smart-card'
+- Discoverable credential flows vs non-discoverable flows
+- AuthenticatorAssertionResponse: clientDataJSON, authenticatorData, signature, userHandle
+- The signature computation: signedData = concat(authenticatorData, SHA-256(clientDataJSON))
+- ECDSA signature format: ASN.1 DER encoding for ES256
+- The authentication ceremony step-by-step
+- Server-side authentication validation: 8-step checklist
+- signCount update logic and synced passkey exception (signCount=0)
+- Credential-to-user binding: CRITICAL (CVE-2025-26788 pattern)
+- Algorithm confusion prevention
+- Cross-ceremony attack prevention via type field validation
+- Step-up authentication pattern
+
+### Key Takeaways
+- The authentication ceremony is entirely stateless on the authenticator — it only signs data; all state lives on the server
+- Consuming the challenge immediately and unconditionally is essential
+- The credential-to-user binding check is omitted by approximately half of custom implementations (CVE-2025-26788)
+- Synced passkeys (signCount=0) require special handling
+- The type field check prevents cross-ceremony attacks
+
+### Practical Exercises
+- Implement authentication verification without a library: manually verify the ECDSA signature
+- Write a test suite covering all 8 validation steps with explicit failure mode test cases
+- Implement a step-up authentication guard middleware
+- Build a discoverable credential flow and trace how userHandle identifies the user
+- Deliberately introduce CVE-2025-26788, exploit it, then fix it
+
+---
+
+## Module 6: Passkeys — Multi-Device Credentials and the Sync Ecosystem
+**Difficulty: Intermediate**
+
+### Topics
+- Official FIDO Alliance definition: passkey as a FIDO credential that allows sign-in using the same process as device unlock
+- Technical definition: WebAuthn credential with BE=1 and BS=1 flags
+- Device-bound vs synced passkeys
+- iCloud Keychain, Google Password Manager, 1Password sync architectures
+- The attack vector: account takeover of the sync account
+- Hybrid QR flow (caBLE/cross-device authentication)
+- Credential Exchange Protocol (CXP) and Credential Exchange Format (CXF)
+- Platform readiness (2026): iOS 100%, Android 100%, Windows 73%, macOS 92%
+- Common misconceptions about passkeys
+- Adoption statistics: 5 billion passkeys active globally
+
+### Key Takeaways
+- Passkeys are a specific credential type within WebAuthn, distinguished by BE and BS flags
+- The sync fabric is the true innovation; the underlying cryptography is unchanged
+- The attack surface is the sync account, not the cryptography
+- Hybrid QR transport never copies the private key
+- CXF/CXP eliminates vendor lock-in objections
+
+### Practical Exercises
+- Register a passkey on iPhone, sign in on Windows via hybrid QR flow
+- Inspect BE and BS flags in real authenticatorData
+- Implement different security policies based on device_type and backup_state
+- Configure 1Password as CTAP2 provider on Android
+- Write non-technical documentation explaining hybrid QR flow
+
+---
+
+## Module 7: Client-Side Implementation
+**Difficulty: Intermediate**
+
+### Topics
+- Secure context requirement (HTTPS)
+- Feature detection: four levels
+- getClientCapabilities() (Chrome 133+, Safari 17.4+)
+- base64url encoding/decoding utilities
+- Level 3 JSON serialization: parseCreationOptionsFromJSON(), parseRequestOptionsFromJSON(), toJSON()
+- Conditional UI implementation details
+- AbortController pattern for SPAs
+- Error types: NotAllowedError, AbortError, InvalidStateError, ConstraintError, SecurityError, DataError, NotSupportedError, UnknownError
+- iOS/Safari user gesture requirement
+- @simplewebauthn/browser and @github/webauthn-json libraries
+- Permissions Policy for cross-origin iframes
+- Cross-origin iframe requirements
+
+### Key Takeaways
+- The conditional get() call must be initiated on page load, not on a button click
+- Never rely on localStorage/cookies to track passkey existence
+- The AbortController is not optional for SPAs
+- parseCreationOptionsFromJSON() and toJSON() eliminate encoding bugs
+- Safari user gesture requirement breaks third-party HTTP libraries
+
+### Practical Exercises
+- Build a complete client-side passkey flow using only the native WebAuthn API
+- Implement Conditional UI with full AbortController lifecycle management
+- Write comprehensive error handler for every WebAuthn error type
+- Compare @simplewebauthn/browser vs native API
+- Test Safari user gesture requirement
+
+---
+
+## Module 8: Server-Side Implementation Across Seven Ecosystems
+**Difficulty: Intermediate**
+
+### Topics
+- Library survey: SimpleWebAuthn (TypeScript), py_webauthn (Python), webauthn-rs (Rust), java-webauthn-server (Java), fido2-net-lib (.NET), go-webauthn (Go), webauthn-ruby (Ruby)
+- Each library's API surface, storage model, and unique features
+- Universal storage requirements
+- Challenge persistence: server-side with TTL, never in stateless JWT
+- PostgreSQL schema design
+- FIDO MDS integration
+
+### Key Takeaways
+- All libraries share identical security invariants; the language changes but the requirements do not
+- Counter update after every authentication is the most commonly skipped operation
+- Storing challenges in JWTs is the most common architectural mistake
+- The CredentialRepository pattern from java-webauthn-server is worth studying
+- webauthn-rs disables state serialization by default for security
+
+### Practical Exercises
+- Implement the same flow in two different languages and compare
+- Build a Redis-backed challenge store with TTL and atomic consume-and-delete
+- Write integration tests for all validation steps
+- Implement the CredentialRepository pattern
+- Create a replay prevention test fixture
+
+---
+
+## Module 9: Security Analysis and Threat Modeling
+**Difficulty: Advanced**
+
+### Topics
+- Phishing resistance: rpIdHash + origin binding (two layers)
+- AiTM proxy attack failure
+- Replay attack prevention: challenge + signCount
+- DEF CON 33: UI-level prompt spoofing against synced passkeys
+- Browser extension attacks: WebAuthn API hijacking
+- CVE-2024-9956 (Chrome Android FIDO URI) and CVE-2025-26788 (StrongKey account takeover)
+- Five most common server-side logic flaws
+- Attestation security vs privacy trade-off
+- Privacy by design: unique keys per site, no cross-site correlation
+- Account recovery as the primary attack surface
+- Post-quantum threat: ML-DSA as planned replacement
+- Algorithm agility design
+
+### Key Takeaways
+- WebAuthn is phishing-resistant by cryptographic construction, but UI-level attacks exist
+- CVE-2025-26788 proves credential-to-user binding is critical
+- Browser extension attacks are outside the WebAuthn threat model
+- Account recovery design deserves equal security rigor
+- Post-quantum migration requires planning now
+
+### Practical Exercises
+- Build a STRIDE threat model for a passkey-protected application
+- Reproduce CVE-2025-26788 in a test environment
+- Implement a complete server-side validation checklist as a tested function
+- Compare passkey, TOTP, and SMS against the AiTM attack model
+- Design Permissions Policy configuration for extension attack mitigation
+
+---
+
+## Module 10: UX Design Patterns for Passkey Adoption
+**Difficulty: Intermediate**
+
+### Topics
+- Triggered enrollment pattern: 102% higher adoption (eBay data)
+- Three-phase progressive enrollment
+- Conditional UI as highest-converting sign-in pattern
+- Convenience framing outperforms security framing
+- Four primary user confusion points
+- Passkey management UI requirements
+- FIDO Alliance UX guidelines: 10 UX principles, 14 design patterns
+- Silent/conditional conversion (Roblox, TikTok)
+- Accessibility: WCAG 3.3.8, screen reader support
+- Real production results: Google 352% growth, TikTok 90%+ success rate, Uber 5x faster, DocuSign 99% success
+
+### Key Takeaways
+- UX directly determines adoption (eBay's 102% increase from prompt timing)
+- OS dialog is platform-owned; bridge with microcopy before and after
+- Launching enrollment without management UI is an anti-pattern
+- Silent conversion is highest-leverage for adoption
+- The 'not now' path must be frictionless
+
+### Practical Exercises
+- Build a triggered enrollment prompt and usability test
+- Implement passkey management page with AAGUID lookup
+- A/B test security vs convenience framing
+- Measure Conditional UI vs password sign-in rates
+- Conduct accessibility audit with NVDA and JAWS
+
+---
+
+## Module 11: Advanced WebAuthn Features and Extensions
+**Difficulty: Advanced**
+
+### Topics
+- PRF extension: HMAC with hardware-bound secret → 32-byte deterministic output
+- PRF key derivation pipeline: PRF output → HKDF → AES-GCM-256
+- Envelope encryption with PRF (Bitwarden model)
+- credProtect extension: three levels
+- Chrome credProtect implicit escalation behavior
+- largeBlob extension: read/write arbitrary binary data on authenticator
+- Signal API: signalUnknownCredential(), signalAllAcceptedCredentials(), signalCurrentUserDetails()
+- Related Origin Requests (ROR): single passkey across multiple domains
+- getClientCapabilities() capabilities map
+- JSON serialization APIs
+- Secure Payment Confirmation (SPC)
+
+### Key Takeaways
+- PRF enables hardware-backed E2E encryption in web applications
+- Signal API solves stale passkey entry problem
+- Related Origin Requests eliminate per-domain passkey registration
+- credProtect's Chrome implicit escalation breaks apps expecting Level 2
+- PRF envelope encryption pattern is production-proven by Bitwarden
+
+### Practical Exercises
+- Implement PRF-based E2E encrypted note-taking app
+- Deploy Signal API after every successful authentication
+- Configure Related Origin Requests for multi-domain site
+- Test credProtect across Chrome and Firefox
+- Implement largeBlob storage on a YubiKey
+
+---
+
+## Module 12: Browser and Platform Support — Compatibility Matrix
+**Difficulty: Intermediate**
+
+### Topics
+- WebAuthn global coverage: 94.05%; passkeys: 91.04%
+- Chrome, Safari, Firefox, Edge version support
+- iOS, Android, Windows, macOS platform support
+- Windows 10 limitations: no Conditional UI, no PRF
+- Linux: no native platform authenticator
+- Android NFC limitation for CTAP2
+- Safari user gesture quirks
+- Firefox Android historical issues
+- PRF support matrix
+- Cross-origin iframe support
+- Hardware security key storage limits
+
+### Key Takeaways
+- Windows 10 is the most significant platform gap
+- Android's NFC limitation is non-obvious
+- Safari's user gesture requirement is the most common cross-browser issue
+- Firefox on Android has been the most problematic
+- Linux requires hybrid QR or hardware key only
+
+### Practical Exercises
+- Build browser capability detection module
+- Test passkey flow on all major platform/browser combinations
+- Implement graceful degradation across support levels
+- Debug Safari user gesture failure
+- Build production support matrix table
+
+---
+
+## Module 13: Enterprise Passkey Deployment
+**Difficulty: Advanced**
+
+### Topics
+- 87% of enterprises deploying or piloting FIDO2 passkeys (2026)
+- IDP-mediated architecture: Okta, Microsoft Entra ID, Auth0
+- Hybrid deployment model: synced + device-bound by role
+- Enterprise Attestation: Vendor Facilitated and Platform Managed
+- Apple MDM passkey attestation
+- Zero Trust integration
+- Crawl-Walk-Run migration framework
+- The bootstrapping paradox and Temporary Access Pass (TAP)
+- Conditional Access policy configuration
+- Cross-Tenant Access Trust for B2B
+- Recovery architecture: five-tier model
+- Compliance: NIST SP 800-63-4, GDPR, NIS2, DORA, PCI DSS 4.0, HIPAA
+
+### Key Takeaways
+- IDP-mediated architecture is the correct enterprise pattern
+- The bootstrapping paradox must be solved before enforcement
+- Attestation must be applied selectively via Passkey Profiles
+- Recovery design requires equal security rigor
+- One FIDO2 deployment satisfies multiple regulatory frameworks
+
+### Practical Exercises
+- Design a complete Crawl-Walk-Run migration plan for 1,000 users
+- Configure Entra ID conditional access without circular lockout
+- Implement automated TAP issuance via Graph API
+- Build AAGUID allowlist enforcement with MDS3
+- Create enterprise attestation policy document
+
+---
+
+## Module 14: Future Trends, Emerging Standards, and the Passkeys Ecosystem
+**Difficulty: Expert**
+
+### Topics
+- WebAuthn Level 3 status and key additions
+- CTAP 2.2 and 2.3 new features
+- Credential Exchange Protocol (CXP/CXF)
+- Secure Payment Confirmation (SPC)
+- Digital Credentials API (W3C) and Verifiable Credentials
+- EU eIDAS 2.0 deadline: December 31, 2026
+- FIDO Alliance Agentic Authentication TWG (April 2026)
+- Post-quantum cryptography: ML-DSA
+- Algorithm agility design principle
+- Passwordless market: $24.1B (2025) → $55.7B (2030)
+
+### Key Takeaways
+- Passkeys and digital credentials converge on navigator.credentials — authentication and identity unify
+- Agentic authentication for AI agents is the next major unsolved problem
+- Post-quantum migration requires algorithm-agile architectures now
+- EU eIDAS 2.0 will make CTAP 2.2 hybrid flow familiar to hundreds of millions
+- WebAuthn/passkeys expertise is career-defining, not niche ($55.7B market by 2030)
+
+### Practical Exercises
+- Implement Secure Payment Confirmation flow
+- Set up Digital Credentials API demonstration
+- Design algorithm-agile passkey storage schema
+- Design delegation token flow for AI agent authentication
+- Build passkey portability demo using CXF specification
+
+---
+
+## Learning Path
+
+Start with Module 1 (History) and Module 2 (Cryptographic Foundations) in parallel — neither depends on the other, and both provide essential context. Complete Module 3 (FIDO2 Architecture) before proceeding, as it establishes the three-party mental model that all subsequent modules assume. Modules 4 and 5 (Registration and Authentication Ceremonies) must be completed in order and form the technical core of the curriculum — do not skip ahead. Module 6 (Passkeys) can be read after Module 4 or alongside Module 5. Modules 7 and 8 (Client-Side and Server-Side Implementation) are best studied together in a practical project that implements a working passkey system end-to-end; begin Module 7 first for the browser API, then Module 8 for the server. Module 9 (Security Analysis) requires Modules 4, 5, 7, and 8 as prerequisites — security analysis without implementation knowledge is purely theoretical. Module 10 (UX Design) can be studied in parallel with Modules 7 and 8 once the basic flow is understood. Module 11 (Advanced Extensions) builds on Module 7 (client-side) and Module 8 (server-side) — PRF requires understanding of the authentication flow before the extension makes sense. Module 12 (Browser Support) is a reference module that should be consulted while building Modules 7 and 8, but read in full after Module 10. Module 13 (Enterprise Deployment) requires Modules 6, 8, 9, and 10 as prerequisites — enterprise context only makes sense after implementation and security are understood. Module 14 (Future Trends) is the capstone and can be read at any point after Module 6, but yields the most insight after completing all previous modules.
+
+**Recommended total time: 120-160 hours** for a developer with intermediate web development experience and no prior WebAuthn knowledge, or **60-80 hours** for someone with cryptography background and prior authentication systems experience.

--- a/docs/course/script.js
+++ b/docs/course/script.js
@@ -1,0 +1,296 @@
+/* WebAuthn & Passkeys 完整學習計畫 — 應用邏輯 */
+
+const COURSE = [LESSON_1, LESSON_2, LESSON_3, LESSON_4, LESSON_5, LESSON_6, LESSON_7, LESSON_8, APPENDIX_A];
+
+/* ========== 應用狀態 ========== */
+let state = {
+  currentView: "overview",
+  currentLesson: 0,
+  completed: JSON.parse(localStorage.getItem("webauthn-course-completed") || "[]"),
+  reviewAnswered: {}
+};
+
+function saveState() {
+  localStorage.setItem("webauthn-course-completed", JSON.stringify(state.completed));
+}
+
+/* ========== 渲染 ========== */
+function renderSidebar() {
+  const list = document.getElementById("lesson-list");
+  list.innerHTML = COURSE.map((lesson, i) => {
+    const isActive = state.currentView === "lesson" && state.currentLesson === i;
+    const isCompleted = state.completed.includes(lesson.id);
+    let cls = "";
+    if (isActive) cls += " active";
+    if (isCompleted) cls += " completed";
+    return `<li>
+      <button class="${cls.trim()}" data-idx="${i}">
+        <span class="lesson-check">${isCompleted ? "✓" : ""}</span>
+        <span>${lesson.id <= 8 ? "第 " + lesson.id + " 課：" : ""}${lesson.title}</span>
+      </button>
+    </li>`;
+  }).join("");
+
+  list.querySelectorAll("button").forEach(btn => {
+    btn.addEventListener("click", () => {
+      const idx = parseInt(btn.dataset.idx);
+      showLesson(idx);
+    });
+  });
+}
+
+function renderOverviewSources() {
+  const el = document.getElementById("overview-sources");
+  el.innerHTML = OVERVIEW_SOURCES.map(s => {
+    let domain = "";
+    try { domain = new URL(s.url).hostname; } catch(e) { domain = s.url; }
+    return `<a href="${s.url}" target="_blank" rel="noopener" class="source-card">
+      <span class="source-domain">${domain}</span>
+      ${s.title}
+    </a>`;
+  }).join("");
+}
+
+function renderTOC() {
+  const el = document.getElementById("toc-list");
+  el.innerHTML = COURSE.map((lesson, i) => {
+    const label = lesson.id <= 8 ? `第 ${lesson.id} 課：` : "";
+    return `<li data-idx="${i}"><strong>${label}</strong>${lesson.title}</li>`;
+  }).join("");
+  el.querySelectorAll("li").forEach(li => {
+    li.addEventListener("click", () => showLesson(parseInt(li.dataset.idx)));
+  });
+}
+
+function updateProgress() {
+  const count = state.completed.length;
+  document.getElementById("progress-label").textContent = `${count} / ${COURSE.length} 課程`;
+  document.getElementById("progress-fill").style.width = `${(count / COURSE.length) * 100}%`;
+}
+
+function showOverview() {
+  state.currentView = "overview";
+  document.getElementById("overview-section").style.display = "";
+  document.getElementById("lesson-section").style.display = "none";
+  document.getElementById("review-section").style.display = "none";
+  renderSidebar();
+  updateProgress();
+}
+
+function showLesson(idx) {
+  state.currentView = "lesson";
+  state.currentLesson = idx;
+  const lesson = COURSE[idx];
+
+  document.getElementById("overview-section").style.display = "none";
+  document.getElementById("lesson-section").style.display = "";
+  document.getElementById("review-section").style.display = "none";
+
+  document.getElementById("lesson-number").textContent = lesson.id <= 8 ? `第 ${lesson.id} 課，共 ${COURSE.length} 課` : `附錄`;
+  document.getElementById("lesson-title").textContent = lesson.title;
+
+  const diffEl = document.getElementById("lesson-difficulty");
+  const diffLabels = { beginner: "入門", intermediate: "中級", advanced: "進階", expert: "專家" };
+  diffEl.textContent = diffLabels[lesson.difficulty] || lesson.difficulty;
+  diffEl.className = `lesson-tag ${lesson.difficulty}`;
+
+  const objList = document.getElementById("objectives-list");
+  objList.innerHTML = lesson.objectives.map(o => `<li>${o}</li>`).join("");
+
+  document.getElementById("lesson-body").innerHTML = lesson.body;
+
+  renderFlashcards(lesson.flashcards);
+  renderQuiz(lesson.quiz);
+  renderLessonSources(lesson.sources);
+
+  document.getElementById("btn-prev").disabled = idx === 0;
+  document.getElementById("btn-next").style.display = idx < COURSE.length - 1 ? "" : "none";
+
+  const isCompleted = state.completed.includes(lesson.id);
+  const completeBtn = document.getElementById("btn-complete");
+  if (isCompleted) {
+    completeBtn.textContent = "✓ 已完成";
+    completeBtn.style.opacity = "0.6";
+  } else {
+    completeBtn.textContent = idx < COURSE.length - 1 ? "完成並繼續 →" : "完成課程";
+    completeBtn.style.opacity = "1";
+  }
+
+  renderSidebar();
+  updateProgress();
+  window.scrollTo(0, 0);
+}
+
+function renderFlashcards(cards) {
+  const deck = document.getElementById("flashcard-deck");
+  deck.innerHTML = cards.map((c, i) => {
+    return `<div class="flashcard" data-idx="${i}">
+      <div class="flashcard-front">${c.front}</div>
+      <div class="flashcard-back">${c.back}</div>
+    </div>`;
+  }).join("");
+  deck.querySelectorAll(".flashcard").forEach(card => {
+    card.addEventListener("click", () => card.classList.toggle("flipped"));
+  });
+}
+
+function renderQuiz(questions) {
+  const container = document.getElementById("quiz-container");
+  container.innerHTML = questions.map((q, qi) => {
+    return `<div class="quiz-q" data-qi="${qi}">
+      <p>${q.question}</p>
+      ${q.options.map((opt, oi) => `<button class="quiz-option" data-qi="${qi}" data-oi="${oi}">${opt}</button>`).join("")}
+      <div class="quiz-feedback" id="quiz-fb-${qi}"></div>
+    </div>`;
+  }).join("");
+
+  container.querySelectorAll(".quiz-option").forEach(btn => {
+    btn.addEventListener("click", () => {
+      const qi = parseInt(btn.dataset.qi);
+      const oi = parseInt(btn.dataset.oi);
+      const q = questions[qi];
+      const fb = document.getElementById(`quiz-fb-${qi}`);
+      const parent = btn.closest(".quiz-q");
+
+      parent.querySelectorAll(".quiz-option").forEach(b => {
+        b.classList.add("dimmed");
+        b.classList.remove("correct", "incorrect");
+      });
+
+      if (oi === q.correct) {
+        btn.classList.remove("dimmed");
+        btn.classList.add("correct");
+        fb.className = "quiz-feedback show correct-fb";
+        fb.textContent = "✓ 正確！" + q.explanation;
+      } else {
+        btn.classList.remove("dimmed");
+        btn.classList.add("incorrect");
+        const correctBtn = parent.querySelectorAll(".quiz-option")[q.correct];
+        correctBtn.classList.remove("dimmed");
+        correctBtn.classList.add("correct");
+        fb.className = "quiz-feedback show incorrect-fb";
+        fb.textContent = "✗ 不正確。" + q.explanation;
+      }
+    });
+  });
+}
+
+function renderLessonSources(sources) {
+  const el = document.getElementById("lesson-sources");
+  el.innerHTML = sources.map(s => {
+    let domain = "";
+    try { domain = new URL(s.url).hostname; } catch(e) { domain = s.url; }
+    return `<a href="${s.url}" target="_blank" rel="noopener" class="source-card">
+      <span class="source-domain">${domain}</span>
+      ${s.title}
+    </a>`;
+  }).join("");
+}
+
+function showReview() {
+  state.currentView = "review";
+  state.reviewAnswered = {};
+  document.getElementById("overview-section").style.display = "none";
+  document.getElementById("lesson-section").style.display = "none";
+  document.getElementById("review-section").style.display = "";
+
+  const container = document.getElementById("review-quiz");
+  container.innerHTML = REVIEW_QUESTIONS.map((q, qi) => {
+    return `<div class="quiz-q" data-qi="${qi}">
+      <p><strong>第 ${qi + 1} 題：</strong>${q.question}</p>
+      ${q.options.map((opt, oi) => `<button class="quiz-option" data-qi="${qi}" data-oi="${oi}">${opt}</button>`).join("")}
+      <div class="quiz-feedback" id="review-fb-${qi}"></div>
+    </div>`;
+  }).join("");
+
+  container.querySelectorAll(".quiz-option").forEach(btn => {
+    btn.addEventListener("click", () => {
+      const qi = parseInt(btn.dataset.qi);
+      const oi = parseInt(btn.dataset.oi);
+      const q = REVIEW_QUESTIONS[qi];
+      const fb = document.getElementById(`review-fb-${qi}`);
+      const parent = btn.closest(".quiz-q");
+
+      if (state.reviewAnswered[qi] !== undefined) return;
+      state.reviewAnswered[qi] = oi === q.correct;
+
+      parent.querySelectorAll(".quiz-option").forEach(b => {
+        b.classList.add("dimmed");
+      });
+
+      if (oi === q.correct) {
+        btn.classList.remove("dimmed");
+        btn.classList.add("correct");
+        fb.className = "quiz-feedback show correct-fb";
+        fb.textContent = "✓ 正確！" + q.explanation;
+      } else {
+        btn.classList.remove("dimmed");
+        btn.classList.add("incorrect");
+        const correctBtn = parent.querySelectorAll(".quiz-option")[q.correct];
+        correctBtn.classList.remove("dimmed");
+        correctBtn.classList.add("correct");
+        fb.className = "quiz-feedback show incorrect-fb";
+        fb.textContent = "✗ 不正確。" + q.explanation;
+      }
+
+      const answered = Object.keys(state.reviewAnswered).length;
+      if (answered === REVIEW_QUESTIONS.length) {
+        const score = Object.values(state.reviewAnswered).filter(Boolean).length;
+        const scoreEl = document.getElementById("review-score");
+        scoreEl.style.display = "";
+        scoreEl.innerHTML = `<div class="score-num">${score} / ${REVIEW_QUESTIONS.length}</div>
+          <p>${score === REVIEW_QUESTIONS.length ? "滿分！你已經完全掌握 WebAuthn & Passkeys 了。" :
+              score >= 6 ? "表現得很好！複習一下答錯的題目，鞍固你的理解。" :
+              "繼續加油！回去複習課程內容，再試一次。"}</p>`;
+      }
+    });
+  });
+
+  document.getElementById("review-score").style.display = "none";
+  renderSidebar();
+  window.scrollTo(0, 0);
+}
+
+/* ========== 事件監聽 ========== */
+document.getElementById("btn-start").addEventListener("click", () => showLesson(0));
+
+document.getElementById("btn-back-overview").addEventListener("click", showOverview);
+document.getElementById("btn-back-from-review").addEventListener("click", showOverview);
+
+document.getElementById("btn-prev").addEventListener("click", () => {
+  if (state.currentLesson > 0) showLesson(state.currentLesson - 1);
+});
+
+document.getElementById("btn-next").addEventListener("click", () => {
+  if (state.currentLesson < COURSE.length - 1) showLesson(state.currentLesson + 1);
+});
+
+document.getElementById("btn-complete").addEventListener("click", () => {
+  const lesson = COURSE[state.currentLesson];
+  if (!state.completed.includes(lesson.id)) {
+    state.completed.push(lesson.id);
+    saveState();
+  }
+  if (state.currentLesson < COURSE.length - 1) {
+    showLesson(state.currentLesson + 1);
+  } else {
+    showReview();
+  }
+});
+
+/* ========== 初始化 ========== */
+renderOverviewSources();
+renderTOC();
+renderSidebar();
+updateProgress();
+
+/* 在側邊欄最後面加上總複習連結 */
+const reviewLi = document.createElement("li");
+reviewLi.style.marginTop = "0.75rem";
+reviewLi.style.paddingTop = "0.75rem";
+reviewLi.style.borderTop = "1px solid var(--border)";
+const reviewBtn = document.createElement("button");
+reviewBtn.innerHTML = '<span class="lesson-check">★</span><span>總複習測驗</span>';
+reviewBtn.addEventListener("click", showReview);
+reviewLi.appendChild(reviewBtn);
+document.getElementById("lesson-list").appendChild(reviewLi);

--- a/docs/course/styles.css
+++ b/docs/course/styles.css
@@ -1,0 +1,475 @@
+/* Design Tokens */
+:root {
+  --bg: #fbf7ef;
+  --surface: #fffdf8;
+  --text: #231f1a;
+  --muted: #766f66;
+  --border: #e8ded0;
+  --primary: #2d2924;
+  --accent: #c2410c;
+  --success: #15803d;
+  --warning: #b45309;
+  --radius: 8px;
+  --font: "Segoe UI", system-ui, -apple-system, sans-serif;
+  --mono: "Cascadia Code", "Fira Code", "Consolas", monospace;
+}
+
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+body {
+  font-family: var(--font);
+  background: var(--bg);
+  color: var(--text);
+  line-height: 1.6;
+  min-height: 100vh;
+}
+
+/* Header */
+.course-header {
+  background: var(--primary);
+  color: #fff;
+  padding: 0.75rem 1.5rem;
+  position: sticky;
+  top: 0;
+  z-index: 100;
+  box-shadow: 0 2px 8px rgba(0,0,0,0.15);
+}
+.header-inner {
+  max-width: 1400px;
+  margin: 0 auto;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+.header-brand { display: flex; align-items: center; gap: 0.75rem; }
+.header-icon { font-size: 1.6rem; }
+.header-title { font-size: 1.1rem; font-weight: 700; line-height: 1.2; }
+.header-sub { font-size: 0.78rem; opacity: 0.7; }
+.header-progress { text-align: right; min-width: 160px; }
+#progress-label { font-size: 0.78rem; opacity: 0.8; }
+.progress-bar {
+  width: 160px;
+  height: 6px;
+  background: rgba(255,255,255,0.2);
+  border-radius: 3px;
+  margin-top: 4px;
+}
+.progress-fill {
+  height: 100%;
+  background: var(--accent);
+  border-radius: 3px;
+  width: 0;
+  transition: width 0.4s ease;
+}
+
+/* Layout */
+.layout {
+  max-width: 1400px;
+  margin: 0 auto;
+  display: grid;
+  grid-template-columns: 260px 1fr;
+  min-height: calc(100vh - 60px);
+}
+
+/* Sidebar */
+.sidebar {
+  background: var(--surface);
+  border-right: 1px solid var(--border);
+  padding: 1.25rem 1rem;
+  position: sticky;
+  top: 60px;
+  height: calc(100vh - 60px);
+  overflow-y: auto;
+}
+.sidebar-heading {
+  font-size: 0.72rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--muted);
+  margin-bottom: 0.75rem;
+  font-weight: 600;
+}
+.lesson-list { list-style: none; }
+.lesson-list li {
+  margin-bottom: 2px;
+}
+.lesson-list button {
+  width: 100%;
+  text-align: left;
+  background: none;
+  border: none;
+  padding: 0.5rem 0.65rem;
+  border-radius: var(--radius);
+  cursor: pointer;
+  font-size: 0.82rem;
+  color: var(--text);
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  transition: background 0.15s;
+  line-height: 1.35;
+}
+.lesson-list button:hover { background: var(--border); }
+.lesson-list button.active { background: var(--accent); color: #fff; font-weight: 600; }
+.lesson-list button.completed .lesson-check { color: var(--success); }
+.lesson-check {
+  width: 18px;
+  height: 18px;
+  flex-shrink: 0;
+  border: 2px solid var(--border);
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.65rem;
+  color: transparent;
+  transition: all 0.2s;
+}
+.lesson-list button.completed .lesson-check {
+  border-color: var(--success);
+  background: #dcfce7;
+}
+.lesson-list button.active .lesson-check { border-color: rgba(255,255,255,0.5); }
+.sidebar-meta {
+  margin-top: 1.5rem;
+  padding-top: 1rem;
+  border-top: 1px solid var(--border);
+  font-size: 0.72rem;
+  color: var(--muted);
+  line-height: 1.5;
+}
+.sidebar-meta p { margin-bottom: 0.35rem; }
+
+/* Main */
+.main { padding: 2rem 2.5rem; max-width: 900px; }
+
+/* Overview */
+.overview-card {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 2rem;
+  margin-bottom: 2rem;
+}
+.overview-card h2 { font-size: 1.4rem; margin-bottom: 0.5rem; }
+.overview-card p { color: var(--muted); margin-bottom: 1.25rem; }
+.overview-stats {
+  display: flex;
+  gap: 1.5rem;
+  margin-bottom: 1.5rem;
+}
+.stat {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+.stat-num { font-size: 1.5rem; font-weight: 700; color: var(--accent); }
+.stat-label { font-size: 0.72rem; color: var(--muted); text-transform: uppercase; letter-spacing: 0.05em; }
+.overview-toc { margin-bottom: 2rem; }
+.overview-toc h3 { font-size: 1rem; margin-bottom: 0.75rem; }
+.toc-list { padding-left: 1.25rem; }
+.toc-list li {
+  padding: 0.35rem 0;
+  font-size: 0.88rem;
+  color: var(--text);
+  cursor: pointer;
+}
+.toc-list li:hover { color: var(--accent); }
+.overview-sources h3 { font-size: 1rem; margin-bottom: 0.75rem; }
+
+/* Buttons */
+.btn-primary {
+  background: var(--accent);
+  color: #fff;
+  border: none;
+  padding: 0.65rem 1.5rem;
+  border-radius: var(--radius);
+  font-size: 0.88rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: opacity 0.15s;
+}
+.btn-primary:hover { opacity: 0.9; }
+.btn-secondary {
+  background: var(--surface);
+  color: var(--text);
+  border: 1px solid var(--border);
+  padding: 0.55rem 1.25rem;
+  border-radius: var(--radius);
+  font-size: 0.85rem;
+  cursor: pointer;
+  transition: background 0.15s;
+}
+.btn-secondary:hover { background: var(--border); }
+.btn-secondary:disabled { opacity: 0.4; cursor: default; }
+.btn-back {
+  background: none;
+  border: none;
+  color: var(--muted);
+  font-size: 0.82rem;
+  cursor: pointer;
+  padding: 0.25rem 0;
+}
+.btn-back:hover { color: var(--accent); }
+.btn-complete {
+  background: var(--success);
+  color: #fff;
+  border: none;
+  padding: 0.55rem 1.25rem;
+  border-radius: var(--radius);
+  font-size: 0.85rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: opacity 0.15s;
+}
+.btn-complete:hover { opacity: 0.9; }
+
+/* Lesson view */
+.lesson-topbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 1rem;
+}
+.lesson-tag {
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  padding: 0.2rem 0.6rem;
+  border-radius: 4px;
+  font-weight: 600;
+}
+.lesson-tag.beginner { background: #dcfce7; color: var(--success); }
+.lesson-tag.intermediate { background: #fef3c7; color: var(--warning); }
+.lesson-tag.advanced { background: #fee2e2; color: #b91c1c; }
+.lesson-tag.expert { background: #ede9fe; color: #6d28d9; }
+
+.lesson-number {
+  font-size: 0.72rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--accent);
+  font-weight: 700;
+  margin-bottom: 0.25rem;
+}
+.lesson-title { font-size: 1.35rem; margin-bottom: 1.25rem; }
+
+.objectives-block {
+  background: #f0fdf4;
+  border: 1px solid #bbf7d0;
+  border-radius: var(--radius);
+  padding: 1rem 1.25rem;
+  margin-bottom: 1.5rem;
+}
+.objectives-block h4 {
+  font-size: 0.78rem;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--success);
+  margin-bottom: 0.5rem;
+}
+.objectives-block ul { padding-left: 1.1rem; }
+.objectives-block li { font-size: 0.85rem; margin-bottom: 0.25rem; }
+
+.lesson-body { margin-bottom: 2rem; }
+.lesson-body h3 {
+  font-size: 1.05rem;
+  margin-top: 1.5rem;
+  margin-bottom: 0.5rem;
+  color: var(--primary);
+}
+.lesson-body p {
+  font-size: 0.88rem;
+  margin-bottom: 0.75rem;
+  line-height: 1.7;
+}
+.lesson-body ul, .lesson-body ol {
+  padding-left: 1.25rem;
+  margin-bottom: 0.75rem;
+}
+.lesson-body li {
+  font-size: 0.88rem;
+  margin-bottom: 0.35rem;
+  line-height: 1.55;
+}
+.lesson-body code {
+  font-family: var(--mono);
+  background: #f5f0e8;
+  padding: 0.1rem 0.35rem;
+  border-radius: 3px;
+  font-size: 0.8rem;
+}
+.lesson-body pre {
+  background: var(--primary);
+  color: #e8e0d4;
+  padding: 1rem 1.25rem;
+  border-radius: var(--radius);
+  overflow-x: auto;
+  font-size: 0.78rem;
+  line-height: 1.55;
+  margin-bottom: 1rem;
+  font-family: var(--mono);
+}
+.lesson-body .callout {
+  background: #fef3c7;
+  border-left: 3px solid var(--warning);
+  padding: 0.75rem 1rem;
+  border-radius: 0 var(--radius) var(--radius) 0;
+  margin-bottom: 1rem;
+  font-size: 0.85rem;
+}
+.lesson-body .callout-critical {
+  background: #fee2e2;
+  border-left-color: #b91c1c;
+}
+
+/* Flashcards */
+.flashcard-section { margin-bottom: 2rem; }
+.flashcard-section h3 { font-size: 1rem; margin-bottom: 0.75rem; }
+.flashcard-deck { display: flex; flex-direction: column; gap: 0.75rem; }
+.flashcard {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 1rem 1.25rem;
+  cursor: pointer;
+  transition: box-shadow 0.15s;
+  user-select: none;
+}
+.flashcard:hover { box-shadow: 0 2px 8px rgba(0,0,0,0.06); }
+.flashcard-front {
+  font-size: 0.88rem;
+  font-weight: 600;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+.flashcard-front::after {
+  content: "點擊翻開";
+  font-size: 0.68rem;
+  color: var(--muted);
+  font-weight: 400;
+}
+.flashcard.flipped .flashcard-front::after { content: "點擊收起"; }
+.flashcard-back {
+  display: none;
+  margin-top: 0.65rem;
+  padding-top: 0.65rem;
+  border-top: 1px solid var(--border);
+  font-size: 0.85rem;
+  color: var(--muted);
+  line-height: 1.6;
+}
+.flashcard.flipped .flashcard-back { display: block; }
+
+/* Quiz */
+.quiz-section { margin-bottom: 2rem; }
+.quiz-section h3 { font-size: 1rem; margin-bottom: 0.75rem; }
+.quiz-q {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 1.25rem;
+  margin-bottom: 1rem;
+}
+.quiz-q p { font-size: 0.88rem; font-weight: 600; margin-bottom: 0.75rem; }
+.quiz-option {
+  display: block;
+  width: 100%;
+  text-align: left;
+  background: none;
+  border: 1px solid var(--border);
+  padding: 0.5rem 0.75rem;
+  border-radius: 6px;
+  margin-bottom: 0.4rem;
+  font-size: 0.82rem;
+  cursor: pointer;
+  transition: all 0.15s;
+}
+.quiz-option:hover { border-color: var(--accent); background: #fef7f0; }
+.quiz-option.correct {
+  border-color: var(--success);
+  background: #dcfce7;
+  pointer-events: none;
+}
+.quiz-option.incorrect {
+  border-color: #b91c1c;
+  background: #fee2e2;
+  pointer-events: none;
+}
+.quiz-option.dimmed { opacity: 0.5; pointer-events: none; }
+.quiz-feedback {
+  margin-top: 0.5rem;
+  font-size: 0.8rem;
+  padding: 0.5rem 0.75rem;
+  border-radius: 6px;
+  display: none;
+}
+.quiz-feedback.show { display: block; }
+.quiz-feedback.correct-fb { background: #dcfce7; color: var(--success); }
+.quiz-feedback.incorrect-fb { background: #fee2e2; color: #b91c1c; }
+
+/* Source cards */
+.source-section { margin-bottom: 2rem; }
+.source-section h3 { font-size: 1rem; margin-bottom: 0.75rem; }
+.source-cards { display: flex; flex-direction: column; gap: 0.5rem; }
+.source-card {
+  display: block;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 0.6rem 0.85rem;
+  text-decoration: none;
+  color: var(--text);
+  font-size: 0.8rem;
+  transition: border-color 0.15s;
+  line-height: 1.4;
+}
+.source-card:hover { border-color: var(--accent); }
+.source-card .source-domain {
+  font-size: 0.68rem;
+  color: var(--accent);
+  display: block;
+  margin-bottom: 0.15rem;
+}
+
+/* Lesson nav */
+.lesson-nav {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  padding-top: 1.5rem;
+  border-top: 1px solid var(--border);
+}
+
+/* Review */
+.review-section { padding: 0; }
+.review-section h2 { font-size: 1.3rem; margin-bottom: 0.5rem; }
+.review-intro { color: var(--muted); font-size: 0.88rem; margin-bottom: 1.5rem; }
+.review-score {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 1.25rem;
+  margin-top: 1.5rem;
+  font-size: 1rem;
+  text-align: center;
+}
+.review-score .score-num { font-size: 2rem; font-weight: 700; color: var(--accent); }
+
+/* Mobile */
+@media (max-width: 800px) {
+  .layout { grid-template-columns: 1fr; }
+  .sidebar {
+    position: static;
+    height: auto;
+    border-right: none;
+    border-bottom: 1px solid var(--border);
+    padding: 1rem;
+  }
+  .main { padding: 1.25rem; }
+  .overview-stats { flex-wrap: wrap; gap: 1rem; }
+  .lesson-nav { flex-direction: column; }
+}


### PR DESCRIPTION
### 摘要
新增一套純靜態、可離線瀏覽的 WebAuthn / Passkeys 互動式學習課程，置於 `docs/course/`，提供從基礎概念到生產部署的完整繁體中文教材。

### 修改內容
- **課程內容（`lessons/lesson-1.js` ~ `lesson-8.js`）**：8 課漸進式課程，涵蓋密碼問題與 FIDO 演進史、WebAuthn 架構、註冊/驗證流程、attestation、安全分析與生產部署等主題
- **附錄與複習（`lessons/appendix-a.js`、`lessons/review.js`）**：補充教材與互動式複習測驗
- **應用框架（`index.html`、`script.js`、`styles.css`）**：單頁式課程介面，含側邊欄課程導覽、進度追蹤（localStorage 持久化）、測驗作答互動
- **研究彙整（`research-synthesis.md`）**：13 個研究主題的課綱彙整文件，作為課程內容的依據來源（含 W3C WebAuthn Level 3、CTAP 2.3、CVE 分析與大型服務部署案例）

### Why
**背景：** 本專案為 WebAuthn 示範專案，新增此課程讓開發者在操作 demo 之外，能系統性理解 Passkeys 的原理、安全模型與部署考量。
**技術理由：** 採用零依賴的純靜態 HTML/JS/CSS，直接以瀏覽器開啟即可使用，不引入額外建置流程或框架，與既有專案結構解耦（全部內容隔離於 `docs/course/`）。

### Testing
- [ ] 單元測試通過且覆蓋新功能（純文件/靜態頁面，不適用）
- [x] 使用者介面變更已完成手動測試（瀏覽器開啟課程頁面、切換課程、作答測驗、進度儲存）
- [x] 效能 / 安全性考量已確認（無外部依賴、無後端互動，僅使用 localStorage）

### ⚠️ 風險評估與破壞性變更
無破壞性變更。所有變更皆為新增檔案且隔離於 `docs/course/`，不影響既有伺服器、前端或建置流程。

### 相關連結
- 無

### 變更類型
- [ ] 新增功能 (feat)
- [ ] 修復錯誤 (fix)
- [ ] 重構 (refactor)
- [x] 文件 (docs)
- [ ] 測試 (tests)
- [ ] 其他 (chore / ci / perf)

### 備註（選填）
- 課程頁面為純靜態檔案，直接以瀏覽器開啟 `docs/course/index.html` 即可瀏覽。
