### PR TITLE
fix(client): 修正進場動畫造成滾動軸閃現

### DIFF
--- a/apps/client/src/index.css
+++ b/apps/client/src/index.css
@@ -52,15 +52,17 @@ html {
   color: #e6eef8;
 }
 
-/* ===== 進場動畫:錯落浮現 ===== */
+/* ===== 進場動畫:錯落浮現 =====
+   以縮放取代位移:起始狀態不超出最終佔位,
+   避免 overflow 容器在進場期間閃現滾動軸 */
 @keyframes vault-rise {
   from {
     opacity: 0;
-    transform: translateY(14px);
+    transform: scale(0.97);
   }
   to {
     opacity: 1;
-    transform: translateY(0);
+    transform: scale(1);
   }
 }
 


### PR DESCRIPTION
### 摘要
修正進入頁面時 y 軸滾動軸短暫出現又消失的問題。

### 修改內容
- `vault-rise` 進場動畫由 `translateY(14px)` 位移改為 `scale(0.97)` 縮放，起始狀態不超出元素最終佔位，`overflow-y-auto` 容器不再於動畫期間產生暫時性 overflow

### Why
位移式進場讓內容短暫超出容器下緣（實測 overflow 8px），觸發滾動軸，動畫結束後消失。縮放起始狀態恆在最終範圍內，實測 overflow 為 0。

### 變更類型
- [ ] 新增功能 (feat)
- [x] 修復錯誤 (fix)
- [ ] 重構 (refactor)
- [ ] 文件 (docs)
- [ ] 測試 (tests)
- [ ] 其他 (chore / ci / perf)
