### PR TITLE
fix(server): 修正錯誤中介層失效並統一以 JSON 回應錯誤

### DIFF
--- a/apps/server/src/app.ts
+++ b/apps/server/src/app.ts
@@ -15,8 +15,16 @@ import authRouter from "./routes/auth";
 import credentialRouter from "./routes/credential";
 import wellknownRouter from "./routes/wellknown";
 import { handleError } from "./middleware";
+import { getExpectedOrigins } from "./utils";
 
 dotenv.config();
+
+// 設定錯誤 fail-fast：allow-list 解析後為空時直接讓服務起不來，
+// 不要等第一個請求才以難以追蹤的 500 暴露
+if (getExpectedOrigins().length === 0) {
+  throw new Error("ALLOWED_ORIGINS 解析後為空，請檢查環境變數設定（逗號分隔的 origin 清單）");
+}
+
 const app = express();
 
 const MemoryStore = memorystore(session);

--- a/apps/server/src/controllers/authentication/authentication.ts
+++ b/apps/server/src/controllers/authentication/authentication.ts
@@ -69,7 +69,7 @@ export const handleAuthStart = async (
       data: options
     });
   } catch (error) {
-    next(error instanceof CustomError ? error : new CustomError("Internal Server Error", 500));
+    next(error);
   }
 };
 
@@ -102,19 +102,28 @@ export const handleAuthFinish = async (
       return next(new CustomError("User is not registered this device", 403));
     }
 
-    const verification = await verifyAuthenticationResponse({
-      response: data,
-      expectedChallenge: currentChallenge,
-      expectedOrigin: getExpectedOrigins(),
-      expectedRPID: process.env.RP_ID,
-      authenticator: {
-        credentialID: new Uint8Array(Base64Url.decodeBase64Url(authenticator.credential_id)),
-        credentialPublicKey: new Uint8Array(Base64Url.decodeBase64Url(authenticator.public_key)),
-        counter: authenticator.counter,
-        transports: JSON.parse(authenticator.transports)
-      },
-      requireUserVerification: true
-    });
+    // SimpleWebAuthn 以 throw 表達驗證失敗，訊息精確（如 origin / RP ID 不符），
+    // 屬 client 端問題回 400，不可吞成 generic 500
+    let verification;
+    try {
+      verification = await verifyAuthenticationResponse({
+        response: data,
+        expectedChallenge: currentChallenge,
+        expectedOrigin: getExpectedOrigins(),
+        expectedRPID: process.env.RP_ID,
+        authenticator: {
+          credentialID: new Uint8Array(Base64Url.decodeBase64Url(authenticator.credential_id)),
+          credentialPublicKey: new Uint8Array(Base64Url.decodeBase64Url(authenticator.public_key)),
+          counter: authenticator.counter,
+          transports: JSON.parse(authenticator.transports)
+        },
+        requireUserVerification: true
+      });
+    } catch (error) {
+      const err = error as Error;
+      console.error("[authentication:finish]", `userId=${loggedInUserId}`, err.stack);
+      return res.status(400).json({ status: "Failed", message: err.message });
+    }
 
     const { verified, authenticationInfo } = verification;
 
@@ -137,7 +146,7 @@ export const handleAuthFinish = async (
       }
     });
   } catch (error) {
-    next(error instanceof CustomError ? error : new CustomError("Internal Server Error", 500));
+    next(error);
   } finally {
     req.session.currentChallenge = undefined;
   }

--- a/apps/server/src/controllers/registration/registration.ts
+++ b/apps/server/src/controllers/registration/registration.ts
@@ -78,7 +78,7 @@ export const handleRegisterStart = async (
       data: options
     });
   } catch (error) {
-    next(error instanceof CustomError ? error : new CustomError("Internal Server Error", 500));
+    next(error);
   }
 };
 
@@ -107,13 +107,22 @@ export const handleRegisterFinish = async (
       return next(new CustomError("缺少必要資訊", 403));
     }
 
-    const verification = await verifyRegistrationResponse({
-      response: data,
-      expectedChallenge: currentChallenge,
-      expectedOrigin: getExpectedOrigins(),
-      expectedRPID: process.env.RP_ID,
-      requireUserVerification: true
-    });
+    // SimpleWebAuthn 以 throw 表達驗證失敗，訊息精確（如 origin / RP ID 不符），
+    // 屬 client 端問題回 400，不可吞成 generic 500
+    let verification;
+    try {
+      verification = await verifyRegistrationResponse({
+        response: data,
+        expectedChallenge: currentChallenge,
+        expectedOrigin: getExpectedOrigins(),
+        expectedRPID: process.env.RP_ID,
+        requireUserVerification: true
+      });
+    } catch (error) {
+      const err = error as Error;
+      console.error("[registration:finish]", `userId=${loggedInUserId}`, err.stack);
+      return res.status(400).json({ status: "Failed", message: err.message });
+    }
 
     if (verification.verified && verification.registrationInfo) {
       const { credentialPublicKey, credentialID, counter } = verification.registrationInfo;
@@ -144,7 +153,7 @@ export const handleRegisterFinish = async (
       next(new CustomError("Verification failed", 400));
     }
   } catch (error) {
-    next(error instanceof CustomError ? error : new CustomError("Internal Server Error", 500));
+    next(error);
   } finally {
     req.session.currentChallenge = undefined;
   }

--- a/apps/server/src/middleware/errorHandler.ts
+++ b/apps/server/src/middleware/errorHandler.ts
@@ -1,8 +1,11 @@
-import { Request, Response } from "express";
+import { Request, Response, NextFunction } from "express";
 import { CustomError } from "./customError";
 
-export function handleError(err: CustomError, req: Request, res: Response) {
+// Express 4 以「4 參數」辨識錯誤處理中介層，少了 next 會被當成一般 middleware 而失效
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+export function handleError(err: CustomError, req: Request, res: Response, next: NextFunction) {
   const statusCode = err.statusCode || 500;
   const message = err.message || "Internal Server Error";
+  console.error(req.method, req.path, err.stack);
   res.status(statusCode).json({ status: "Error", message: message });
 }


### PR DESCRIPTION
### 摘要
修正 server 端錯誤處理三層缺位，讓 API 錯誤一律以 JSON 回應並在 log 留下完整 stack，使 macOS 註冊 finish 階段的 500 能直接呈現根因訊息。

### 修改內容
- `middleware/errorHandler.ts`：`handleError` 原本只有 3 個參數，Express 4 以「4 參數」辨識錯誤處理中介層，導致它從未生效、錯誤全部落到 Express 預設 HTML 錯誤頁（500 + HTML 的根因）。改為 4 參數簽名，並加上 `console.error(req.method, req.path, err.stack)`。
- `registration.ts` / `authentication.ts` finish handlers：SimpleWebAuthn 的 verify 呼叫單獨包 try/catch，throw 視為驗證失敗，回 `400 {"status":"Failed","message":...}` 並 log 上下文與 stack，不再吞成 generic 500。
- start / finish 外層 catch：原本 `next(new CustomError("Internal Server Error", 500))` 會吃掉真實錯誤訊息，改為 `next(error)` 交由 final error middleware JSON 化。
- `app.ts`：啟動時驗證 `getExpectedOrigins()` 非空，解析為空則直接 throw fail-fast，不等第一個請求才炸成 500。

### Why
origin 改成 allow-list（#22）後 verify 失敗分支首次真正被走到，暴露出錯誤處理缺口：500 + HTML、log 只有 `Error: Internal Server Error`，無法定位 macOS 註冊失敗的根因。

### 驗收
- curl PUT 亂造 body → `400` + JSON（不再是 HTML 錯誤頁）。
- 模擬 verify 失敗 → `400 {"status":"Failed","message":"Unexpected registration response origin \"...\", expected one of: ..."}`，log 含 stack 與 userId。
- `ALLOWED_ORIGINS` 設定但解析為空 → 啟動失敗並印出設定錯誤（完全未設定時仍 fallback 至程式內預設清單，allow-list 邏輯未動）。
- `tsc --noEmit` 無新增型別錯誤（既有錯誤不在本次範圍）。

### 變更類型
- [ ] 新增功能 (feat)
- [x] 修復錯誤 (fix)
- [ ] 重構 (refactor)
- [ ] 文件 (docs)
- [ ] 測試 (tests)
- [ ] 其他 (chore / ci / perf)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
